### PR TITLE
feat: direct user to download Keplr extension

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,8 +8,10 @@ import ChainConnection from 'components/ChainConnection';
 import { INTER_LOGO } from 'assets/assets';
 
 import 'styles/globals.css';
+import Prerequisites, { hasPrerequisites } from 'Prerequisites';
 
 const App = () => {
+  if (!hasPrerequisites()) return <Prerequisites />;
   return (
     <>
       <ToastContainer

--- a/src/Prerequisites.tsx
+++ b/src/Prerequisites.tsx
@@ -1,0 +1,38 @@
+import { INTER_LOGO } from 'assets/assets';
+
+export const hasPrerequisites = () => 'keplr' in window;
+
+const Prerequisites = () => {
+  return (
+    <>
+      <div>
+        <div className="min-w-screen container p-4 mx-auto flex justify-between items-center">
+          <a href="https://inter.trade/" target="inter.trade">
+            <img
+              src={INTER_LOGO}
+              className="item"
+              alt="Inter Logo"
+              width="200"
+            />
+          </a>
+        </div>
+        <div className="max-w-md mx-auto flex-col	mt-16">
+          <h1 className="text-xl font-semibold">Prerequisites</h1>
+          <p>
+            This dapp depends on the <a href="https://www.keplr.app/">Keplr</a>{' '}
+            browser extension to function.
+          </p>
+          <a
+            href="https://www.keplr.app/download"
+            target="keplr_download"
+            className="mx-auto text-xl text-blue-500 hover:text-blue-700"
+          >
+            Install
+          </a>
+        </div>
+      </div>
+    </>
+  );
+};
+
+export default Prerequisites;


### PR DESCRIPTION
<img width="860" alt="Screen Shot 2022-10-28 at 10 09 36 AM" src="https://user-images.githubusercontent.com/21505/198694167-4c3b209d-a893-4033-bfa2-099ef3c86b29.png">

The Keplr extension is available for Chrome and Firefox. Tested in both browsers.