### PR TITLE
fix: wait for keplr before lockdown

### DIFF
--- a/src/installSesLockdown.ts
+++ b/src/installSesLockdown.ts
@@ -1,12 +1,35 @@
 import { lockdown } from '@endo/lockdown';
 import '@endo/eventual-send/shim.js'; // adds support needed by E
 
-const consoleTaming = import.meta.env.DEV ? 'unsafe' : 'safe';
+const MAX_ATTEMPTS = 10;
+const WAIT_PER_ATTEMPT = 10;
+let attempts = 0;
+const startWhenKeplrAvailable = (res: () => void) => {
+  console.debug('looking for keplr');
 
-lockdown({
-  errorTaming: 'unsafe',
-  overrideTaming: 'severe',
-  consoleTaming,
-});
+  attempts += 1;
 
-Error.stackTraceLimit = Infinity;
+  // @ts-expect-error cast
+  if (window.keplr) {
+    const consoleTaming = import.meta.env.DEV ? 'unsafe' : 'safe';
+
+    lockdown({
+      errorTaming: 'unsafe',
+      overrideTaming: 'severe',
+      consoleTaming,
+    });
+
+    Error.stackTraceLimit = Infinity;
+
+    console.log('Lockdown done.');
+    res();
+  } else {
+    if (attempts < MAX_ATTEMPTS) {
+      setTimeout(() => startWhenKeplrAvailable(res), WAIT_PER_ATTEMPT);
+    } else {
+      alert('This site requires the Keplr extension');
+    }
+  }
+};
+
+await new Promise<void>(res => startWhenKeplrAvailable(res));

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,4 +1,4 @@
-import './installSesLockdown';
+await import('./installSesLockdown');
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import App from './App';

--- a/test/loadKeplr.ts
+++ b/test/loadKeplr.ts
@@ -1,0 +1,2 @@
+// @ts-expect-error expects keplr in window
+global.window = { keplr: {} };

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -6,10 +6,10 @@ import tsconfigPaths from 'vite-tsconfig-paths';
 export default defineConfig({
   optimizeDeps: {
     include: ['@endo/init'],
-    esbuildOptions: { target: 'es2020', supported: { bigint: true } },
+    esbuildOptions: { target: 'esnext', supported: { bigint: true } },
   },
   plugins: [react(), tsconfigPaths()],
   build: {
-    target: 'es2020',
+    target: 'esnext',
   },
 });

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -6,7 +6,7 @@ export default mergeConfig(
   viteConfig,
   defineConfig({
     test: {
-      setupFiles: ['src/installSesLockdown.ts'],
+      setupFiles: ['test/loadKeplr.ts', 'src/installSesLockdown.ts'],
     },
   })
 );

--- a/yarn.lock
+++ b/yarn.lock
@@ -3014,7 +3014,7 @@ eslint@^8.22.0:
     strip-json-comments "^3.1.0"
     text-table "^0.2.0"
 
-"esm@github:agoric-labs/esm#Agoric-built":
+esm@agoric-labs/esm#Agoric-built:
   version "3.2.25"
   resolved "https://codeload.github.com/agoric-labs/esm/tar.gz/3603726ad4636b2f865f463188fcaade6375638e"
 
@@ -4740,7 +4740,7 @@ rollup-pluginutils@^2.4.1:
   dependencies:
     estree-walker "^0.6.1"
 
-rollup@endojs/endo#rollup-2.7.1-patch-1, "rollup@github:endojs/endo#rollup-2.7.1-patch-1":
+rollup@endojs/endo#rollup-2.7.1-patch-1:
   version "2.70.1-endo.1"
   resolved "https://codeload.github.com/endojs/endo/tar.gz/54060e784a4dbe77b6692f17344f4d84a198530d"
   optionalDependencies:


### PR DESCRIPTION
refs https://github.com/Agoric/dapp-psm/issues/65

This will be cherry-picked into `beta` branch afterwards (or manually patched in if cherry-pick fails)