### PR TITLE
fix: serialize offer amounts without rounding

### DIFF
--- a/mock/brand.mock.ts
+++ b/mock/brand.mock.ts
@@ -8,4 +8,5 @@ export const mockBrand = () =>
     getDisplayInfo: () => ({
       assetKind: AssetKind.NAT,
     }),
+    getAmountShape: () => '',
   });

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "eslint-plugin-react": "^7.30.1",
     "eslint-plugin-react-hooks": "^4.6.0",
     "framer-motion": "^7.2.1",
+    "happy-dom": "^10.7.0",
     "jotai": "^1.8.0",
     "lodash-es": "4.17.21",
     "patch-package": "^7.0.0",

--- a/src/services/swap.ts
+++ b/src/services/swap.ts
@@ -1,8 +1,7 @@
 import type { PursesJSONState } from '@agoric/wallet-backend';
+import type { WalletBridge } from 'store/app';
 import { E } from '@endo/eventual-send';
-
 import { SwapDirection } from 'store/swap';
-import { WalletBridge } from 'store/app';
 import { AmountMath } from '@agoric/ertp';
 
 type SwapContext = {

--- a/src/services/swap.ts
+++ b/src/services/swap.ts
@@ -3,6 +3,7 @@ import { E } from '@endo/eventual-send';
 
 import { SwapDirection } from 'store/swap';
 import { WalletBridge } from 'store/app';
+import { AmountMath } from '@agoric/ertp';
 
 type SwapContext = {
   wallet: WalletBridge;
@@ -30,7 +31,11 @@ export const makeSwapOffer = async ({
       ? 'makeWantMintedInvitation'
       : 'makeGiveMintedInvitation';
 
-  const serializedInstance = await E(marshal).serialize(instanceId);
+  const [serializedInstance, serializedIn, serializedOut] = await Promise.all([
+    E(marshal).serialize(instanceId),
+    E(marshal).serialize(AmountMath.make(fromPurse.brand, fromValue)),
+    E(marshal).serialize(AmountMath.make(toPurse.brand, toValue)),
+  ]);
 
   const offerConfig = {
     publicInvitationMaker: method,
@@ -38,14 +43,12 @@ export const makeSwapOffer = async ({
     proposalTemplate: {
       give: {
         In: {
-          pursePetname: fromPurse.pursePetname,
-          value: Number(fromValue),
+          amount: serializedIn,
         },
       },
       want: {
         Out: {
-          pursePetname: toPurse.pursePetname,
-          value: Number(toValue),
+          amount: serializedOut,
         },
       },
     },

--- a/test/services/swap.test.ts
+++ b/test/services/swap.test.ts
@@ -1,0 +1,49 @@
+import { expect, it, describe } from 'vitest';
+import { mockBrand } from '../../mock/brand.mock';
+import { makeMarshal } from '@endo/marshal';
+import { makeSwapOffer } from '../../src/services/swap';
+import { SwapDirection } from '../../src/store/swap';
+import { AmountMath } from '@agoric/ertp';
+
+describe('helpers', () => {
+  const minted = mockBrand();
+  const anchor = mockBrand();
+
+  it('serializes the amounts properly', async () => {
+    let config: any;
+    const wallet = {
+      addOffer: offerConfig => {
+        config = offerConfig;
+      },
+    };
+
+    const marshal = makeMarshal();
+
+    const d = 10n ** 18n;
+    const fromValue = 5000n * d;
+    const toValue = 50_000n * d;
+
+    expect(Number(fromValue) > Number.MAX_SAFE_INTEGER).toBe(true);
+
+    await makeSwapOffer({
+      wallet,
+      instanceId: '123',
+      fromPurse: { brand: anchor },
+      fromValue,
+      toPurse: { brand: minted },
+      toValue,
+      swapDirection: SwapDirection.WantMinted,
+      marshal,
+    });
+
+    const fromAmount = marshal.fromCapData(
+      config.proposalTemplate.give.In.amount
+    );
+    const toAmount = marshal.fromCapData(
+      config.proposalTemplate.want.Out.amount
+    );
+
+    expect(AmountMath.isEqual(AmountMath.make(anchor, fromValue), fromAmount));
+    expect(AmountMath.isEqual(AmountMath.make(minted, toValue), toAmount));
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -7,6 +7,7 @@ export default mergeConfig(
   defineConfig({
     test: {
       setupFiles: ['src/installSesLockdown.ts'],
+      environment: 'happy-dom',
     },
   })
 );

--- a/yarn.lock
+++ b/yarn.lock
@@ -2844,6 +2844,11 @@ css-to-react-native@^3.0.0:
     css-color-keywords "^1.0.0"
     postcss-value-parser "^4.0.2"
 
+css.escape@^1.5.1:
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/css.escape/-/css.escape-1.5.1.tgz#42e27d4fa04ae32f931a4b4d4191fa9cddee97cb"
+  integrity sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==
+
 cssesc@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/cssesc/-/cssesc-3.0.0.tgz#37741919903b868565e1c09ea747445cd18983ee"
@@ -3065,6 +3070,11 @@ end-of-stream@^1.1.0, end-of-stream@^1.4.1:
   integrity sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==
   dependencies:
     once "^1.4.0"
+
+entities@^4.5.0:
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/entities/-/entities-4.5.0.tgz#5d268ea5e7113ec74c4d033b79ea5a35a488fb48"
+  integrity sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==
 
 es-abstract@^1.19.0, es-abstract@^1.19.1, es-abstract@^1.19.2, es-abstract@^1.19.5:
   version "1.20.4"
@@ -3840,6 +3850,18 @@ grapheme-splitter@^1.0.4:
   resolved "https://registry.yarnpkg.com/grapheme-splitter/-/grapheme-splitter-1.0.4.tgz#9cf3a665c6247479896834af35cf1dbb4400767e"
   integrity sha512-bzh50DW9kTPM00T8y4o8vQg89Di9oLJVLW/KaOGIXJWP/iqCN6WKYkbNOF04vFLJhwcpYUh9ydh/+5vpOqV4YQ==
 
+happy-dom@^10.7.0:
+  version "10.7.0"
+  resolved "https://registry.yarnpkg.com/happy-dom/-/happy-dom-10.7.0.tgz#923236e1377b983c51eee51b0b0035acde361f90"
+  integrity sha512-dJFPbA7KW4kkH3MFJBPTX73ywOfcrJcu6CAUw0CnCH0aEDcnPNG8QVmOAxsJSvTZFzLCnmSx/jMzAp00hdm0gw==
+  dependencies:
+    css.escape "^1.5.1"
+    entities "^4.5.0"
+    iconv-lite "^0.6.3"
+    webidl-conversions "^7.0.0"
+    whatwg-encoding "^2.0.0"
+    whatwg-mimetype "^3.0.0"
+
 has-bigints@^1.0.1, has-bigints@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/has-bigints/-/has-bigints-1.0.2.tgz#0871bd3e3d51626f6ca0966668ba35d5602d6eaa"
@@ -3909,6 +3931,13 @@ hoist-non-react-statics@^3.0.0:
   integrity sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==
   dependencies:
     react-is "^16.7.0"
+
+iconv-lite@0.6.3, iconv-lite@^0.6.3:
+  version "0.6.3"
+  resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.6.3.tgz#a52f80bf38da1952eb5c681790719871a1a72501"
+  integrity sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==
+  dependencies:
+    safer-buffer ">= 2.1.2 < 3.0.0"
 
 iconv-lite@^0.4.24:
   version "0.4.24"
@@ -5411,7 +5440,7 @@ safe-stable-stringify@^2.3.1:
   resolved "https://registry.yarnpkg.com/safe-stable-stringify/-/safe-stable-stringify-2.4.3.tgz#138c84b6f6edb3db5f8ef3ef7115b8f55ccbf886"
   integrity sha512-e2bDA2WJT0wxseVd4lsDP4+3ONX6HpMXQa1ZhFQ7SU+GjvORCmShbCMltrtIDfkYhVHrOcPtj+KhmDBdPdZD1g==
 
-"safer-buffer@>= 2.1.2 < 3":
+"safer-buffer@>= 2.1.2 < 3", "safer-buffer@>= 2.1.2 < 3.0.0":
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
   integrity sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==
@@ -6055,6 +6084,23 @@ webidl-conversions@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-3.0.1.tgz#24534275e2a7bc6be7bc86611cc16ae0a5654871"
   integrity sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==
+
+webidl-conversions@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-7.0.0.tgz#256b4e1882be7debbf01d05f0aa2039778ea080a"
+  integrity sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==
+
+whatwg-encoding@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/whatwg-encoding/-/whatwg-encoding-2.0.0.tgz#e7635f597fd87020858626805a2729fa7698ac53"
+  integrity sha512-p41ogyeMUrw3jWclHWTQg1k05DSVXPLcVxRTYsXUk+ZooOCZLcoYgPZ/HL/D/N+uQPOtcp1me1WhBEaX02mhWg==
+  dependencies:
+    iconv-lite "0.6.3"
+
+whatwg-mimetype@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/whatwg-mimetype/-/whatwg-mimetype-3.0.0.tgz#5fa1a7623867ff1af6ca3dc72ad6b8a4208beba7"
+  integrity sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==
 
 whatwg-url@^5.0.0:
   version "5.0.0"


### PR DESCRIPTION
From community discord:
```
Guys do you use floats for representing numbers on 'https://psm.inter.trade/' ?

If that is the case please fix it ASAP, because it literally makes app unusuable in some cases. Try DAI which have 18 decimal points and ex. >5000 amount. You'll get not matching input/output numbers due to floating numbers rounding. And it wil will make the transaction fail. 
```

We do in fact pass the offer with floats instead of properly serializing the bigints. This fixes that to properly serialize the amounts the same way dapp-inter does.