### PR TITLE
ci: added daily test for emerynet

### DIFF
--- a/.github/workflows/e2e_tests.yml
+++ b/.github/workflows/e2e_tests.yml
@@ -37,7 +37,7 @@ jobs:
 
       - name: Run e2e tests
         run: |
-          docker-compose -f tests/e2e/docker-compose.yml --profile ${{ github.event_name == 'schedule' && 'daily-tests' || 'synpress' }} up --build --exit-code-from synpress
+          docker-compose -f tests/e2e/docker-compose.yml --profile $SYNPRESS_PROFILE  up --build --exit-code-from synpress
         env:
           COMPOSE_DOCKER_CLI_BUILD: 1
           DOCKER_BUILDKIT: 1
@@ -55,6 +55,7 @@ jobs:
           COMMIT_INFO_MESSAGE: ${{ github.event.pull_request.title }}
           COMMIT_INFO_SHA: ${{ github.event.pull_request.head.sha }}
           CYPRESS_AGORIC_NET: "${{ github.event_name == 'schedule' && 'emerynet' || 'local' }}"
+          SYNPRESS_PROFILE: ${{ github.event_name == 'schedule' && 'daily-tests' || 'synpress' }}
 
       - name: Archive e2e artifacts
         uses: actions/upload-artifact@v3

--- a/.github/workflows/e2e_tests.yml
+++ b/.github/workflows/e2e_tests.yml
@@ -5,6 +5,8 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  schedule:
+    - cron: '0 0 * * *'
 
 concurrency:
   group: '${{ github.workflow }} @ ${{ github.event.pull_request.head.label ||
@@ -35,7 +37,7 @@ jobs:
 
       - name: Run e2e tests
         run: |
-          docker-compose -f tests/e2e/docker-compose.yml --profile synpress up --build --exit-code-from synpress
+          docker-compose -f tests/e2e/docker-compose.yml --profile ${{ github.event_name == 'schedule' && 'daily-tests' || 'synpress' }} up --build --exit-code-from synpress
         env:
           COMPOSE_DOCKER_CLI_BUILD: 1
           DOCKER_BUILDKIT: 1
@@ -52,6 +54,7 @@ jobs:
           CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}
           COMMIT_INFO_MESSAGE: ${{ github.event.pull_request.title }}
           COMMIT_INFO_SHA: ${{ github.event.pull_request.head.sha }}
+          CYPRESS_AGORIC_NET: "${{ github.event_name == 'schedule' && 'emerynet' || 'local' }}"
 
       - name: Archive e2e artifacts
         uses: actions/upload-artifact@v3

--- a/.github/workflows/e2e_tests.yml
+++ b/.github/workflows/e2e_tests.yml
@@ -39,6 +39,10 @@ jobs:
         run: |
           docker-compose -f tests/e2e/docker-compose.yml --profile $SYNPRESS_PROFILE  up --build --exit-code-from synpress
         env:
+          # conditionals based on github event
+          SYNPRESS_PROFILE: ${{ github.event_name == 'schedule' && 'daily-tests' || 'synpress' }}
+          CYPRESS_AGORIC_NET: ${{ github.event_name == 'schedule' && 'emerynet' || 'local' }}
+          # for docker-compose.yml
           COMPOSE_DOCKER_CLI_BUILD: 1
           DOCKER_BUILDKIT: 1
           DOCKER_DEFAULT_PLATFORM: linux/amd64
@@ -54,8 +58,6 @@ jobs:
           CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}
           COMMIT_INFO_MESSAGE: ${{ github.event.pull_request.title }}
           COMMIT_INFO_SHA: ${{ github.event.pull_request.head.sha }}
-          CYPRESS_AGORIC_NET: "${{ github.event_name == 'schedule' && 'emerynet' || 'local' }}"
-          SYNPRESS_PROFILE: ${{ github.event_name == 'schedule' && 'daily-tests' || 'synpress' }}
 
       - name: Archive e2e artifacts
         uses: actions/upload-artifact@v3

--- a/tests/e2e/docker-compose.yml
+++ b/tests/e2e/docker-compose.yml
@@ -4,6 +4,7 @@ services:
   synpress:
     profiles:
       - synpress
+      - daily-tests
     container_name: synpress
     build: ../..
     environment:
@@ -34,24 +35,26 @@ services:
       - GITHUB_REF=${GITHUB_REF}
       - GITHUB_BASE_REF=${GITHUB_BASE_REF}
       - GITHUB_HEAD_REF=${GITHUB_HEAD_REF}
+      # Variables for dapp-psm
+      - CYPRESS_AGORIC_NET=${CYPRESS_AGORIC_NET}
       - SECRET_WORDS="orbit bench unit task food shock brand bracket domain regular warfare company announce wheel grape trust sphere boy doctor half guard ritual three ecology"
     depends_on:
       - display
       - video
-      - agd
     entrypoint: []
     working_dir: /app
     volumes:
       - ./docker/videos:/app/tests/e2e/videos
       - ./docker/screenshots:/app/tests/e2e/screenshots
     command: >
-      bash -c 'echo -n "======> local noVNC URL: http://localhost:8080/vnc.html?autoconnect=true " && pnpm wait-on http://display:8080 && echo -n "======> remote noVNC URL: " && curl -s ngrok:4040/api/tunnels | jq -r .tunnels[0].public_url && nginx && yarn test:e2e:ci'
+      bash -c 'echo -n "======> local noVNC URL: http://localhost:8080/vnc.html?autoconnect=true " && pnpm wait-on http://display:8080 && echo -n "======> remote noVNC URL: " && curl -s ngrok:4040/api/tunnels | jq -r .tunnels[0].public_url && if [ "$CYPRESS_AGORIC_NET" == "local" ]; then nginx; fi && yarn test:e2e:ci'
     networks:
       - x11
 
   display:
     profiles:
       - synpress
+      - daily-tests
     container_name: display
     image: synthetixio/display:016121eafdfff448414894d0ca5a50b1d72b62eb-base
     environment:
@@ -82,6 +85,7 @@ services:
   video:
     profiles:
       - synpress
+      - daily-tests
     container_name: video
     image: synthetixio/video:457bb48776c3b14de232d9dda620ba9188dc40ac-base
     volumes:

--- a/tests/e2e/specs/swap-tokens.spec.js
+++ b/tests/e2e/specs/swap-tokens.spec.js
@@ -1,5 +1,21 @@
 /* eslint-disable ui-testing/no-disabled-tests */
 describe('Swap Tokens Tests', () => {
+  const limitFloat = float => parseFloat(float.toFixed(5));
+  const amountToSwap = 0.001;
+  const phrasesList = {
+    emerynet: {
+      walletButton: 'li[data-value="testnet"]',
+      psmNetwork: 'Agoric Emerynet',
+      token: 'ToyUSD',
+    },
+    local: {
+      walletButton: 'li[data-value="local"]',
+      psmNetwork: 'Local Network',
+      token: 'USDC_axl',
+    },
+  };
+  const networkPhrases = phrasesList[Cypress.env('AGORIC_NET')];
+
   it(`should connect with Agoric Chain on https;//wallet.agoric.app`, () => {
     cy.origin('https://wallet.agoric.app/', () => {
       cy.visit('/');
@@ -8,18 +24,22 @@ describe('Swap Tokens Tests', () => {
       expect(taskCompleted).to.be.true;
     });
 
-    cy.origin('https://wallet.agoric.app/', () => {
-      cy.visit('/wallet/');
+    cy.origin(
+      'https://wallet.agoric.app/',
+      { args: { networkPhrases } },
+      ({ networkPhrases }) => {
+        cy.visit('/wallet/');
 
-      cy.get('input.PrivateSwitchBase-input').click();
-      cy.contains('Proceed').click();
+        cy.get('input.PrivateSwitchBase-input').click();
+        cy.contains('Proceed').click();
 
-      cy.get('button[aria-label="Settings"]').click();
+        cy.get('button[aria-label="Settings"]').click();
 
-      cy.get('#demo-simple-select').click();
-      cy.get('li[data-value="local"]').click();
-      cy.contains('button', 'Connect').click();
-    });
+        cy.get('#demo-simple-select').click();
+        cy.get(networkPhrases.walletButton).click();
+        cy.contains('button', 'Connect').click();
+      }
+    );
 
     cy.acceptAccess().then(taskCompleted => {
       expect(taskCompleted).to.be.true;
@@ -31,7 +51,7 @@ describe('Swap Tokens Tests', () => {
 
     // Switch to local network
     cy.get('button').contains('Agoric Mainnet').click();
-    cy.get('button').contains('Local Network').click();
+    cy.get('button').contains(networkPhrases.psmNetwork).click();
 
     // Click the connect button
     cy.get('button').contains('Connect Keplr').click();
@@ -44,30 +64,32 @@ describe('Swap Tokens Tests', () => {
   });
 
   it('should swap tokens from IST to stable', () => {
-    let ISTbalance;
+    let istBalance;
 
     // Connect wallet
     cy.visit('/');
     cy.get('button').contains('Connect Keplr').click();
 
     cy.addNewTokensFound();
-    cy.getTokenAmount('IST').then(amount => (ISTbalance = amount));
+    cy.getTokenAmount('IST').then(amount => (istBalance = amount));
 
     // Select asset and swap positions
     cy.get('button').contains('Select asset').click();
-    cy.get('button').contains('USDC_axl').click();
+    cy.get('button').contains(networkPhrases.token).click();
     cy.get('svg.transform.rotate-90').click();
 
-    // Swap 1 IST
-    cy.get('input[type="number"]').first().type(1);
+    // Swap token
+    cy.get('input[type="number"]').first().type(amountToSwap);
     cy.get('button').contains('Swap').click();
 
     // Confirm transactions
     cy.confirmTransaction();
-    cy.get('div').contains('Swap Completed').should('be.visible');
+    cy.get('div')
+      .contains('Swap Completed', { timeout: 60000 })
+      .should('be.visible');
 
     cy.getTokenAmount('IST').then(amount =>
-      expect(amount).to.equal(ISTbalance - 1)
+      expect(amount).to.equal(limitFloat(istBalance - amountToSwap))
     );
   });
 
@@ -82,18 +104,20 @@ describe('Swap Tokens Tests', () => {
 
     // Select asset
     cy.get('button').contains('Select asset').click();
-    cy.get('button').contains('USDC_axl').click();
+    cy.get('button').contains(networkPhrases.token).click();
 
-    // Swap 1 USDC_axl
-    cy.get('input[type="number"]').first().type(1);
+    // Swap token
+    cy.get('input[type="number"]').first().type(amountToSwap);
     cy.get('button').contains('Swap').click();
 
     // Confirm transactions
     cy.confirmTransaction();
-    cy.get('div').contains('Swap Completed').should('be.visible');
+    cy.get('div')
+      .contains('Swap Completed', { timeout: 60000 })
+      .should('be.visible');
 
     cy.getTokenAmount('IST').then(amount =>
-      expect(amount).to.equal(ISTbalance + 1)
+      expect(amount).to.equal(limitFloat(ISTbalance + amountToSwap))
     );
   });
 });


### PR DESCRIPTION
This PR does the following:
- Updates the tests to use `emerynet` or `local` network depending on what value is passed in the `CYPRESS_AGORIC_NET` env variable.
- adds a scheduled run to the E2E tests workflow that triggers the test to run once a day. this scheduled test will use the `emerynet` while other tests will use `local`
- made some other updates to tests such as :
  - adding `limitFloat` to reduce errors due to comparison of floating point numbers
  - increasing timeout for transactions on emerynet