### PR TITLE
test: updated tests to handle case with transaction fee

### DIFF
--- a/tests/e2e/specs/swap-tokens.spec.js
+++ b/tests/e2e/specs/swap-tokens.spec.js
@@ -2,6 +2,7 @@
 describe('Swap Tokens Tests', () => {
   const limitFloat = float => parseFloat(float.toFixed(5));
   const amountToSwap = 0.001;
+  const transactionFee = 0.2;
   const phrasesList = {
     emerynet: {
       walletButton: 'li[data-value="testnet"]',
@@ -89,7 +90,10 @@ describe('Swap Tokens Tests', () => {
       .should('be.visible');
 
     cy.getTokenAmount('IST').then(amount =>
-      expect(amount).to.equal(limitFloat(istBalance - amountToSwap))
+      expect(amount).to.be.oneOf([
+        limitFloat(istBalance - amountToSwap),
+        limitFloat(istBalance - amountToSwap - transactionFee),
+      ])
     );
   });
 
@@ -117,7 +121,10 @@ describe('Swap Tokens Tests', () => {
       .should('be.visible');
 
     cy.getTokenAmount('IST').then(amount =>
-      expect(amount).to.equal(limitFloat(ISTbalance + amountToSwap))
+      expect(amount).to.be.oneOf([
+        limitFloat(ISTbalance + amountToSwap),
+        limitFloat(ISTbalance + amountToSwap - transactionFee),
+      ])
     );
   });
 });


### PR DESCRIPTION
Fixes #137 

Root Cause:
PSM transaction have a transaction fee that occurs in the background. Each transaction has a small fee that is accumulated until a total of 0.2 IST worth of transaction fees have been added. At that point, a transaction fee of 0.2 IST occurs.
This happens after ~25 transactions.
This fee was not accounted for in the tests, causing a failure.

Fix:
Since it is difficult to know when the transaction fee will be included, we have opted to compare the received value against two different numbers: the expected value and the expected value - 0.2.