### PR TITLE
test: fix for DEFAULT_TIMEOUT missing in args

### DIFF
--- a/tests/e2e/specs/swap-tokens.spec.js
+++ b/tests/e2e/specs/swap-tokens.spec.js
@@ -27,8 +27,8 @@ describe('Swap Tokens Tests', () => {
       // Provision IST for wallet
       cy.origin(
         'https://emerynet.faucet.agoric.net',
-        { args: { walletAddress } },
-        ({ walletAddress }) => {
+        { args: { walletAddress, DEFAULT_TIMEOUT } },
+        ({ walletAddress, DEFAULT_TIMEOUT }) => {
           cy.visit('/');
           cy.get('[id="address"]').first().type(walletAddress.value);
           cy.get('[type="radio"][value="client"]').click();


### PR DESCRIPTION
fixes the issue where DEFAULT_TIMEOUT variable is not in the scope of cy.origin unless it passed in as an argument