### PR TITLE
ci: allow user to pass secret words as a property when manually triggering tests

### DIFF
--- a/.github/workflows/e2e_tests.yml
+++ b/.github/workflows/e2e_tests.yml
@@ -17,6 +17,10 @@ on:
         options:
           - local
           - emerynet
+      phrase:
+        description: 'The mnemonic phrase for the account to use in testing'
+        required: false
+        type: text
 
 concurrency:
   group: '${{ github.workflow }} @ ${{ github.event.pull_request.head.label ||
@@ -65,6 +69,7 @@ jobs:
           ANVIL_FORK_URL: ${{ secrets.ANVIL_FORK_URL }}
           GH_PAT: ${{ secrets.GH_PAT }}
           GH_USERNAME: ${{ secrets.GH_USERNAME }}
+          CYPRESS_MNEMONIC_PHRASE: ${{ inputs.phrase }}
           # cypress dashboard
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CYPRESS_PROJECT_ID: ${{ secrets.CYPRESS_PROJECT_ID }}

--- a/tests/e2e/docker-compose.yml
+++ b/tests/e2e/docker-compose.yml
@@ -38,6 +38,7 @@ services:
       # Variables for dapp-psm
       - CYPRESS_AGORIC_NET=${CYPRESS_AGORIC_NET}
       - SECRET_WORDS="orbit bench unit task food shock brand bracket domain regular warfare company announce wheel grape trust sphere boy doctor half guard ritual three ecology"
+      - CYPRESS_MNEMONIC_PHRASE=${CYPRESS_MNEMONIC_PHRASE}
     depends_on:
       - display
       - video

--- a/tests/e2e/specs/swap-tokens.spec.js
+++ b/tests/e2e/specs/swap-tokens.spec.js
@@ -9,9 +9,14 @@ describe('Swap Tokens Tests', () => {
     value: null,
   };
   const networkPhrases = phrasesList[Cypress.env('AGORIC_NET')];
+  const customWalletPhrase = Cypress.env('MNEMONIC_PHRASE');
 
   it('should setup wallet for test', () => {
-    if (networkPhrases.isLocal) {
+    if (customWalletPhrase) {
+      cy.setupWallet({
+        secretWords: customWalletPhrase,
+      });
+    } else if (networkPhrases.isLocal) {
       cy.setupWallet();
     } else {
       cy.setupWallet({
@@ -80,9 +85,11 @@ describe('Swap Tokens Tests', () => {
     cy.get('button').contains('Swap').click();
 
     // Should show dialog for wallet provision
-    if (!networkPhrases.isLocal) {
+    let provisionFee = 0;
+    if (!customWalletPhrase && !networkPhrases.isLocal) {
       cy.contains('h3', 'Smart Wallet Required').should('exist');
       cy.contains('button', 'Proceed').click();
+      provisionFee = 0.75;
     }
 
     // Confirm transactions
@@ -93,13 +100,8 @@ describe('Swap Tokens Tests', () => {
 
     cy.getTokenAmount('IST').then(amount =>
       expect(amount).to.be.oneOf([
-        limitFloat(istBalance - amountToSwap - networkPhrases.provisionFee),
-        limitFloat(
-          istBalance -
-            amountToSwap -
-            networkPhrases.provisionFee -
-            transactionFee
-        ),
+        limitFloat(istBalance - amountToSwap - provisionFee),
+        limitFloat(istBalance - amountToSwap - provisionFee - transactionFee),
       ])
     );
   });

--- a/tests/e2e/utils.js
+++ b/tests/e2e/utils.js
@@ -6,13 +6,11 @@ export const phrasesList = {
     psmNetwork: 'Agoric Emerynet',
     token: 'ToyUSD',
     isLocal: false,
-    provisionFee: 0.75,
   },
   local: {
     walletButton: 'li[data-value="local"]',
     psmNetwork: 'Local Network',
     token: 'USDC_axl',
     isLocal: true,
-    provisionFee: 0,
   },
 };


### PR DESCRIPTION
this feature allows us to pass our own custom wallet to the CI setup to bypass the wallet setup in emerynet tests
This allows us to bypass the flaky parts of our test (due to emerynet faucet)
![image](https://github.com/Agoric/dapp-psm/assets/8860764/947934be-6e62-4a7b-b94d-5d984dc73518)
