### PR TITLE
test: updated tests to reduce flakiness for wallet setup

### DIFF
--- a/tests/e2e/specs/swap-tokens.spec.js
+++ b/tests/e2e/specs/swap-tokens.spec.js
@@ -25,26 +25,10 @@ describe('Swap Tokens Tests', () => {
         selectedChains: ['Agoric'],
       });
 
-      cy.getWalletAddress('Agoric').then(
-        address => (walletAddress.value = address)
-      );
-
-      // Provision IST for wallet
-      cy.origin(
-        'https://emerynet.faucet.agoric.net',
-        { args: { walletAddress, DEFAULT_TIMEOUT } },
-        ({ walletAddress, DEFAULT_TIMEOUT }) => {
-          cy.visit('/');
-          cy.get('[id="address"]').first().type(walletAddress.value);
-          cy.get('[type="radio"][value="client"]').click();
-          cy.get('[name="clientType"]').select('REMOTE_WALLET');
-
-          cy.get('[type="submit"]').first().click();
-          cy.get('body')
-            .contains('success', { timeout: DEFAULT_TIMEOUT })
-            .should('exist');
-        }
-      );
+      cy.getWalletAddress('Agoric').then(address => {
+        // provision IST
+        cy.provisionFromFaucet(address, 'client', 'REMOTE_WALLET');
+      });
     }
   });
 

--- a/tests/e2e/support.js
+++ b/tests/e2e/support.js
@@ -1,19 +1,22 @@
 import '@agoric/synpress/support/index';
 import { FACUET_HEADERS, FACUET_URL, DEFAULT_TIMEOUT } from './utils';
 
-Cypress.Commands.add('provisionFromFaucet', (walletAddress, command, clientType) => {
-  cy.request({
-    method: 'POST',
-    url: FACUET_URL,
-    body: {
-      address: walletAddress,
-      command,
-      clientType,
-    },
-    headers: FACUET_HEADERS,
-    timeout: 4 * DEFAULT_TIMEOUT,
-    retryOnStatusCodeFailure: true,
-  }).then(resp => {
-    expect(resp.body).to.eq('success');
-  });
-});
+Cypress.Commands.add(
+  'provisionFromFaucet',
+  (walletAddress, command, clientType) => {
+    cy.request({
+      method: 'POST',
+      url: FACUET_URL,
+      body: {
+        address: walletAddress,
+        command,
+        clientType,
+      },
+      headers: FACUET_HEADERS,
+      timeout: 4 * DEFAULT_TIMEOUT,
+      retryOnStatusCodeFailure: true,
+    }).then(resp => {
+      expect(resp.body).to.eq('success');
+    });
+  }
+);

--- a/tests/e2e/support.js
+++ b/tests/e2e/support.js
@@ -1,1 +1,19 @@
 import '@agoric/synpress/support/index';
+import { FACUET_HEADERS, FACUET_URL, DEFAULT_TIMEOUT } from './utils';
+
+Cypress.Commands.add('provisionFromFaucet', (walletAddress, command, clientType) => {
+  cy.request({
+    method: 'POST',
+    url: FACUET_URL,
+    body: {
+      address: walletAddress,
+      command,
+      clientType,
+    },
+    headers: FACUET_HEADERS,
+    timeout: 4 * DEFAULT_TIMEOUT,
+    retryOnStatusCodeFailure: true,
+  }).then(resp => {
+    expect(resp.body).to.eq('success');
+  });
+});

--- a/tests/e2e/utils.js
+++ b/tests/e2e/utils.js
@@ -14,3 +14,11 @@ export const phrasesList = {
     isLocal: true,
   },
 };
+
+export const FACUET_URL = 'https://emerynet.faucet.agoric.net/go';
+
+export const FACUET_HEADERS = {
+  Accept:
+    'text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.7',
+  'Content-Type': 'application/x-www-form-urlencoded',
+};


### PR DESCRIPTION
This PR updates the flow for provisoing tokens using the emerynet faucet. previously we were doing it through the emerynet faucet ui, but now we are performing it through direct API request, which allows us to retry on failure