### PR TITLE
feat: alert slack if e2e tests fail

### DIFF
--- a/.github/actions/notify-status/action.yml
+++ b/.github/actions/notify-status/action.yml
@@ -1,0 +1,22 @@
+name: Notify GitHub Actions Status on Slack
+description: Notify Slack about the status of GitHub Actions jobs
+
+inputs:
+  webhook:
+    description: 'Slack Webhook URL to send the alerts'
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Send GitHub Actions Status to Slack
+      id: slack
+      uses: slackapi/slack-github-action@v1.26.0
+      with:
+        payload: |
+          {
+            "text": "Job ${{ github.job }} in workflow ${{ github.workflow }} of repository ${{ github.repository }} has a status of ${{ job.status }}.\nDetails: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}",
+            "username": "GitHub Actions"
+          }
+      env:
+        SLACK_WEBHOOK_URL: ${{ inputs.webhook }}

--- a/.github/workflows/e2e_tests.yml
+++ b/.github/workflows/e2e_tests.yml
@@ -87,3 +87,12 @@ jobs:
             tests/e2e/docker/videos-ci
             tests/e2e/docker/screenshots
         continue-on-error: true
+
+      - name: Notify About Failure
+        if: >
+          failure() && github.event_name != 'pull_request' &&
+          github.repository_owner == 'agoric'
+        uses: ./.github/actions/notify-action.yml
+        with:
+          webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
+        continue-on-error: true


### PR DESCRIPTION
The PR adds CI implementation for sending alerts on Slack when E2E tests fail. 