### PR TITLE
ci: change docker-compose to docker compose

### DIFF
--- a/.github/workflows/e2e_tests.yml
+++ b/.github/workflows/e2e_tests.yml
@@ -38,23 +38,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
-
-      - name: Cache Docker layers
-        uses: actions/cache@v3
-        with:
-          path: /tmp/.buildx-cache
-          key: ${{ runner.os }}-buildx-${{ github.sha }}
-          restore-keys: |
-            ${{ runner.os }}-buildx-
-
       - name: Run e2e tests
         run: |
-          docker-compose -f tests/e2e/docker-compose.yml --profile $SYNPRESS_PROFILE  up --build --exit-code-from synpress
+          docker compose -f tests/e2e/docker-compose.yml --profile $SYNPRESS_PROFILE  up --build --exit-code-from synpress
         env:
           # conditionals based on github event
           SYNPRESS_PROFILE: ${{ env.IS_EMERYNET_TEST == 'true' && 'daily-tests' || 'synpress' }}


### PR DESCRIPTION
Refs: https://github.com/Agoric/dapp-econ-gov/issues/111
Fixes some flakes in e2e testing.

- Firstly used docker compose instead of docker-compose (which is not being recognized by github actions)
- Secondly removed some unnecessary steps to give some space to the github runner, otherwise the job was failing due to space limit being reached