### PR TITLE
test: added timeouts before checking balance amount

### DIFF
--- a/tests/e2e/specs/swap-tokens.spec.js
+++ b/tests/e2e/specs/swap-tokens.spec.js
@@ -82,6 +82,7 @@ describe('Swap Tokens Tests', () => {
       .contains('Swap Completed', { timeout: DEFAULT_TIMEOUT })
       .should('be.visible');
 
+    cy.wait(5000);
     cy.getTokenAmount('IST').then(amount =>
       expect(amount).to.be.oneOf([
         limitFloat(istBalance - amountToSwap - provisionFee),
@@ -113,6 +114,7 @@ describe('Swap Tokens Tests', () => {
       .contains('Swap Completed', { timeout: DEFAULT_TIMEOUT })
       .should('be.visible');
 
+    cy.wait(5000);
     cy.getTokenAmount('IST').then(amount =>
       expect(amount).to.be.oneOf([
         limitFloat(ISTbalance + amountToSwap),


### PR DESCRIPTION
This fixes a flake in the tests where after performing a transaction, the updated balance might not reflected in the keplr wallet immediately, resulting in the test thinking the balance hadnt changed.
To fix this, a timeout delay has been added in order to give the chain enough time to update the balance after the transaction and show the correct balance in keplr