### PR TITLE
ci: update cf pages user agent name

### DIFF
--- a/.github/workflows/cf-logs-fetcher.yml
+++ b/.github/workflows/cf-logs-fetcher.yml
@@ -4,7 +4,7 @@ on:
     types: [created, edited]
 jobs:
   fetch_comment_log:
-    if: ${{ (github.event.issue.pull_request) && (github.event.comment.user.login == 'cloudflare-pages[bot]' ) }}
+    if: ${{ (github.event.issue.pull_request) && (github.event.comment.user.login == 'cloudflare-workers-and-pages[bot]' ) }}
     runs-on: [ubuntu-latest]
     steps:
       - name: Fetch & Print The Deployment Logs


### PR DESCRIPTION
Updates CF pages user agent name so the relevant workflow posts build logs (like it used to)

More details [here](https://github.com/Agoric/documentation/pull/1237#issue-2575681568)