### PR TITLE
feat!: ist winddown

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "build": "vite build",
     "preview": "vite preview",
     "lint": "eslint src",
+    "lint:types": "echo 'XXX tsc is not working, even though vite build is successful' && tsc --noEmit",
     "format": "prettier --write . && yarn lint --fix",
     "test": "vitest",
     "coverage": "vitest run --coverage",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "tsc && vite build",
+    "build": "vite build",
     "preview": "vite preview",
     "lint": "eslint src",
     "format": "prettier --write . && yarn lint --fix",
@@ -25,7 +25,7 @@
     "@agoric/smart-wallet": "^0.5.3",
     "@agoric/synpress": "^3.8.5-beta.0",
     "@agoric/ui-components": "^0.9.0",
-    "@agoric/web-components": "^0.15.0",
+    "@agoric/web-components": "^0.17.0",
     "@agoric/zoe": "^0.26.2",
     "@endo/eventual-send": "^1.1.2",
     "@headlessui/react": "^1.6.6",

--- a/src/components/ChainConnection.tsx
+++ b/src/components/ChainConnection.tsx
@@ -4,7 +4,7 @@ import { toast } from 'react-toastify';
 import { Oval } from 'react-loader-spinner';
 import {
   makeAgoricWalletConnection,
-  AgoricKeplrConnectionErrors as Errors,
+  Errors,
   suggestChain,
 } from '@agoric/web-components';
 import {

--- a/src/components/ProvisionSmartWalletDialog.tsx
+++ b/src/components/ProvisionSmartWalletDialog.tsx
@@ -9,6 +9,7 @@ const useSmartWalletFeeQuery = (rpc?: string) => {
   const [smartWalletFee, setFee] = useState<{
     fee: bigint;
     feeUnit: bigint;
+    feeUnitName?: string;
   } | null>(null);
   const [error, setError] = useState<Error | null>(null);
 
@@ -24,8 +25,13 @@ const useSmartWalletFeeQuery = (rpc?: string) => {
         const feeUnit = params.params.beansPerUnit.find(
           ({ key }: { key: string }) => key === 'feeUnit'
         )?.beans;
+        const feeUnitName = params.params?.feeUnitPrice[0]?.denom;
         assert(feeUnit);
-        setFee({ fee: BigInt(beansPerSmartWallet), feeUnit: BigInt(feeUnit) });
+        setFee({
+          fee: BigInt(beansPerSmartWallet),
+          feeUnit: BigInt(feeUnit),
+          feeUnitName,
+        });
       } catch (e) {
         setError(e as Error);
       }
@@ -54,12 +60,20 @@ const ProvisionSmartWalletNoticeDialog = ({
   const { smartWalletFee, error: _smartWalletFeeError } =
     useSmartWalletFeeQuery(rpc);
 
+  const feeUnitNameForDisplay =
+    smartWalletFee?.feeUnitName === 'uist' ? 'IST' : 'BLD';
   const smartWalletFeeForDisplay = smartWalletFee
-    ? String(smartWalletFee.fee / smartWalletFee.feeUnit) + ' IST'
+    ? String(smartWalletFee.fee / smartWalletFee.feeUnit) +
+      ' ' +
+      feeUnitNameForDisplay
     : null;
 
   const purses = useAtomValue(pursesAtom);
   const istPurse = purses?.find(p => p.brandPetname === 'IST');
+  const bldPurse = purses?.find(p => p.brandPetname === 'BLD');
+  const purseToDisplay =
+    smartWalletFee?.feeUnitName === 'uist' ? istPurse : bldPurse;
+
   const { displayAmount, getDecimalPlaces } =
     useAtomValue(displayFunctionsAtom) ?? {};
 
@@ -73,37 +87,41 @@ const ProvisionSmartWalletNoticeDialog = ({
         &quot;Proceed&quot; to provision wallet and submit transaction.
       </div>
       <div className="my-4 flex justify-center gap-4">
-        {istPurse && displayAmount && (
+        {purseToDisplay && displayAmount && (
           <div className="flex items-center">
             <span>
-              IST Balance: <b>{displayAmount(istPurse.currentAmount)}</b>
+              {feeUnitNameForDisplay} Balance:{' '}
+              <b>{displayAmount(purseToDisplay.currentAmount)}</b>
             </span>
           </div>
         )}
-        {istPurse && (
+        {purseToDisplay && (
           <LeapLiquidityModal
-            selectedAsset={istPurse.brand}
+            selectedAsset={purseToDisplay.brand}
             direction={Direction.deposit}
           />
         )}
       </div>
     </>
   );
-  const istDecimals =
-    istPurse && getDecimalPlaces && getDecimalPlaces(istPurse.brand);
+  const decimalsToDisplay =
+    purseToDisplay &&
+    getDecimalPlaces &&
+    getDecimalPlaces(purseToDisplay.brand);
 
   // "feeUnit" is observed to be 1000000000000n, so when "fee" is 1000000000000n
   // that means 1 IST (after dividing "fee" by "feeUnit"). To convert to uIST,
   // we then multiply by 10^6.
   const denominatedSmartWalletFee =
-    istDecimals &&
+    decimalsToDisplay &&
     smartWalletFee &&
-    (smartWalletFee.fee / smartWalletFee.feeUnit) * 10n ** BigInt(istDecimals);
+    (smartWalletFee.fee / smartWalletFee.feeUnit) *
+      10n ** BigInt(decimalsToDisplay);
 
   const hasRequiredFee =
     denominatedSmartWalletFee &&
-    istPurse !== undefined &&
-    istPurse.currentAmount.value >= denominatedSmartWalletFee;
+    purseToDisplay !== undefined &&
+    purseToDisplay.currentAmount.value >= denominatedSmartWalletFee;
 
   return (
     <ActionsDialog

--- a/src/components/ProvisionSmartWalletDialog.tsx
+++ b/src/components/ProvisionSmartWalletDialog.tsx
@@ -9,7 +9,7 @@ const useSmartWalletFeeQuery = (rpc?: string) => {
   const [smartWalletFee, setFee] = useState<{
     fee: bigint;
     feeUnit: bigint;
-    feeUnitName?: string;
+    feeUnitName: string;
   } | null>(null);
   const [error, setError] = useState<Error | null>(null);
 
@@ -26,7 +26,10 @@ const useSmartWalletFeeQuery = (rpc?: string) => {
           ({ key }: { key: string }) => key === 'feeUnit'
         )?.beans;
         const feeUnitName = params.params?.feeUnitPrice[0]?.denom;
-        assert(feeUnit);
+        assert(
+          beansPerSmartWallet && feeUnit && feeUnitName,
+          'missing fee params'
+        );
         setFee({
           fee: BigInt(beansPerSmartWallet),
           feeUnit: BigInt(feeUnit),

--- a/tests/e2e/specs/swap-tokens.spec.js
+++ b/tests/e2e/specs/swap-tokens.spec.js
@@ -87,6 +87,8 @@ describe('Swap Tokens Tests', () => {
       expect(amount).to.be.oneOf([
         limitFloat(istBalance - amountToSwap - provisionFee),
         limitFloat(istBalance - amountToSwap - provisionFee - transactionFee),
+        limitFloat(istBalance - amountToSwap), // If provision fee in IST is removed
+        limitFloat(istBalance - amountToSwap - transactionFee),
       ])
     );
   });

--- a/yarn.lock
+++ b/yarn.lock
@@ -74,6 +74,19 @@
     "@endo/pass-style" "^0.1.4"
     "@endo/patterns" "^0.2.3"
 
+"@agoric/base-zone@^0.1.1-u20.0":
+  version "0.1.1-u20.0"
+  resolved "https://registry.yarnpkg.com/@agoric/base-zone/-/base-zone-0.1.1-u20.0.tgz#38b5b396b49e6e7ac89b7d59e2e2b2d89893302e"
+  integrity sha512-8D7tYBkfjET5zwLTbFHPZZOF43uBn2+uBd/3vcLp/OwsbjGuF7pgh9vPkX1pPcrMj8irduezAN7JHk9ry1KP0Q==
+  dependencies:
+    "@agoric/store" "^0.9.3-u20.0"
+    "@endo/common" "^1.2.10"
+    "@endo/errors" "^1.2.10"
+    "@endo/exo" "^1.5.9"
+    "@endo/far" "^1.1.11"
+    "@endo/pass-style" "^1.5.0"
+    "@endo/patterns" "^1.5.0"
+
 "@agoric/cache@^0.3.2":
   version "0.3.2"
   resolved "https://registry.yarnpkg.com/@agoric/cache/-/cache-0.3.2.tgz#19c3576b72084c3b2409fa4b2fd8f534531c0788"
@@ -126,7 +139,7 @@
     "@endo/promise-kit" "0.2.56"
     node-fetch "^2.6.0"
 
-"@agoric/cosmic-proto@^0.3.0":
+"@agoric/cosmic-proto@0.3.0", "@agoric/cosmic-proto@^0.3.0":
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/@agoric/cosmic-proto/-/cosmic-proto-0.3.0.tgz#c9d31d3946c91fbb1630f89d8ba63a662bcdacc5"
   integrity sha512-cIunby6gs53sGkHx3ALraREbfVQXvsIcObMjQQ0/tZt5HVqwoS7Y1Qj1Xl0ZZvqE8B1Zyk7QMDj829mbTII+9g==
@@ -148,6 +161,23 @@
     "@endo/marshal" "^0.8.5"
     "@endo/nat" "^4.1.27"
     "@endo/promise-kit" "^0.2.56"
+
+"@agoric/ertp@^0.16.3-dev-e2e36cc.0":
+  version "0.16.3-u20.0"
+  resolved "https://registry.yarnpkg.com/@agoric/ertp/-/ertp-0.16.3-u20.0.tgz#c79873ce33aa3b888c32427550bdd60ffce3b1f5"
+  integrity sha512-qs27aew0GVx+mx2DLTjovQ9vnpEr3SDqaPrBtcDV/W5ubyfXPsmKZrIG8y0437OsPM94IcQnudc5zW7Z0qmfMQ==
+  dependencies:
+    "@agoric/notifier" "^0.7.0-u20.0"
+    "@agoric/store" "^0.9.3-u20.0"
+    "@agoric/vat-data" "^0.5.3-u20.0"
+    "@agoric/zone" "^0.3.0-u20.0"
+    "@endo/errors" "^1.2.10"
+    "@endo/eventual-send" "^1.3.1"
+    "@endo/far" "^1.1.11"
+    "@endo/marshal" "^1.6.4"
+    "@endo/nat" "^5.1.0"
+    "@endo/patterns" "^1.5.0"
+    "@endo/promise-kit" "^1.1.10"
 
 "@agoric/governance@^0.10.3":
   version "0.10.3"
@@ -238,6 +268,26 @@
     anylogger "^0.21.0"
     jessie.js "^0.3.2"
 
+"@agoric/internal@^0.4.0-u20.0":
+  version "0.4.0-u20.0"
+  resolved "https://registry.yarnpkg.com/@agoric/internal/-/internal-0.4.0-u20.0.tgz#6093825ddaf9f64ca6389dbf1f0de07d60c566e4"
+  integrity sha512-PZHcAKvFYS6mW9cxkwjV5OAPAvKYpCqT96lQPrRjWPhQrZBUfMvQwZ+AJ20Px2Br7rEEZLbP2FnJ0eEdXdOOHg==
+  dependencies:
+    "@agoric/base-zone" "^0.1.1-u20.0"
+    "@endo/common" "^1.2.10"
+    "@endo/compartment-mapper" "^1.6.0"
+    "@endo/errors" "^1.2.10"
+    "@endo/far" "^1.1.11"
+    "@endo/init" "^1.1.9"
+    "@endo/marshal" "^1.6.4"
+    "@endo/nat" "^5.1.0"
+    "@endo/pass-style" "^1.5.0"
+    "@endo/patterns" "^1.5.0"
+    "@endo/promise-kit" "^1.1.10"
+    "@endo/stream" "^1.2.10"
+    anylogger "^0.21.0"
+    jessie.js "^0.3.4"
+
 "@agoric/notifier@^0.6.2":
   version "0.6.2"
   resolved "https://registry.yarnpkg.com/@agoric/notifier/-/notifier-0.6.2.tgz#d32404671a042267321ef5df7cf5ce0f16d3e777"
@@ -267,6 +317,19 @@
     "@endo/far" "0.2.18"
     "@endo/marshal" "0.8.5"
     "@endo/promise-kit" "0.2.56"
+
+"@agoric/notifier@^0.7.0-u20.0":
+  version "0.7.0-u20.0"
+  resolved "https://registry.yarnpkg.com/@agoric/notifier/-/notifier-0.7.0-u20.0.tgz#daec53fcbf1a2c292e04d2ced10ab0a48d20bb55"
+  integrity sha512-FstGzJkdt1cs19VuOrgDCJkRyMK9TrQbSM44zGAIzYi86p291rfR3/wvoSuXJFlwlGO0DYy7gh40Emyio6i76Q==
+  dependencies:
+    "@agoric/internal" "^0.4.0-u20.0"
+    "@agoric/vat-data" "^0.5.3-u20.0"
+    "@endo/errors" "^1.2.10"
+    "@endo/far" "^1.1.11"
+    "@endo/marshal" "^1.6.4"
+    "@endo/patterns" "^1.5.0"
+    "@endo/promise-kit" "^1.1.10"
 
 "@agoric/rpc@^0.9.0":
   version "0.9.0"
@@ -366,6 +429,17 @@
     "@endo/pass-style" "0.1.3"
     "@endo/patterns" "0.2.2"
 
+"@agoric/store@^0.9.3-u20.0":
+  version "0.9.3-u20.0"
+  resolved "https://registry.yarnpkg.com/@agoric/store/-/store-0.9.3-u20.0.tgz#93b0d9a0dc63f8ddede4096f8928e01772bc0568"
+  integrity sha512-ch7cJhs4vfebIAgpOpzF0C5WdUTzpE3O0haVHxctsBB1Uo+/HaEPL8XtJ7togKbagjjEAIIZ8ZRASK4cHfyFBA==
+  dependencies:
+    "@endo/errors" "^1.2.10"
+    "@endo/exo" "^1.5.9"
+    "@endo/marshal" "^1.6.4"
+    "@endo/pass-style" "^1.5.0"
+    "@endo/patterns" "^1.5.0"
+
 "@agoric/swing-store@^0.9.1":
   version "0.9.1"
   resolved "https://registry.yarnpkg.com/@agoric/swing-store/-/swing-store-0.9.1.tgz#0ed85beac7a7cd2e8e7507ea58e50eecb08a203e"
@@ -428,6 +502,25 @@
     "@endo/pass-style" "0.1.3"
     "@endo/patterns" "0.2.2"
     "@endo/promise-kit" "0.2.56"
+
+"@agoric/swingset-liveslots@^0.10.3-u20.0":
+  version "0.10.3-u20.0"
+  resolved "https://registry.yarnpkg.com/@agoric/swingset-liveslots/-/swingset-liveslots-0.10.3-u20.0.tgz#e78db5e4f2f4fc4d738991dfd61996e29b794ed3"
+  integrity sha512-/am2HmK2FnVnQMVX9NuyFDVzA0HM/462KOmGPRtd2YB9Y+AklVqdfKG7gwtfCqkwsXGSuBEfG0AUooUakUs5iQ==
+  dependencies:
+    "@agoric/internal" "^0.4.0-u20.0"
+    "@agoric/store" "^0.9.3-u20.0"
+    "@endo/env-options" "^1.1.8"
+    "@endo/errors" "^1.2.10"
+    "@endo/eventual-send" "^1.3.1"
+    "@endo/exo" "^1.5.9"
+    "@endo/far" "^1.1.11"
+    "@endo/init" "^1.1.9"
+    "@endo/marshal" "^1.6.4"
+    "@endo/nat" "^5.1.0"
+    "@endo/pass-style" "^1.5.0"
+    "@endo/patterns" "^1.5.0"
+    "@endo/promise-kit" "^1.1.10"
 
 "@agoric/swingset-vat@^0.32.2":
   version "0.32.2"
@@ -588,6 +681,18 @@
     "@agoric/internal" "^0.4.0-u13.0"
     "@agoric/store" "^0.9.3-u13.0"
 
+"@agoric/vat-data@^0.5.3-u20.0":
+  version "0.5.3-u20.0"
+  resolved "https://registry.yarnpkg.com/@agoric/vat-data/-/vat-data-0.5.3-u20.0.tgz#db30d092e792634ae51fc761833c792eaeb5f1d3"
+  integrity sha512-qZymtAM8i3qHuFzQymMJY7hgGsEKVxLm2nJCqqVc2avUB98N48WJfXX6zXb9q0kyGCSSa+P6SsgC2tRE5aBHLg==
+  dependencies:
+    "@agoric/base-zone" "^0.1.1-u20.0"
+    "@agoric/store" "^0.9.3-u20.0"
+    "@agoric/swingset-liveslots" "^0.10.3-u20.0"
+    "@endo/errors" "^1.2.10"
+    "@endo/exo" "^1.5.9"
+    "@endo/patterns" "^1.5.0"
+
 "@agoric/vats@^0.15.1":
   version "0.15.1"
   resolved "https://registry.yarnpkg.com/@agoric/vats/-/vats-0.15.1.tgz#95d43742d5375b2c0718b5f899fb7eb87aaa3b7b"
@@ -614,40 +719,21 @@
     "@endo/promise-kit" "^0.2.56"
     jessie.js "^0.3.2"
 
-"@agoric/wallet-ui@0.1.3-solo.0":
-  version "0.1.3-solo.0"
-  resolved "https://registry.yarnpkg.com/@agoric/wallet-ui/-/wallet-ui-0.1.3-solo.0.tgz#5f05c3dd2820d4f1efcbccbd2dc1292847ecbd2b"
-  integrity sha512-NbhCrTH9u2af+6ituM99M8Mo10VOP1nQRTZoYEXW+esBwJId/7cRniMmAC7qmkbXs8POA31S8EQ5gAhkWq08WA==
-
-"@agoric/wallet@^0.18.3":
-  version "0.18.3"
-  resolved "https://registry.yarnpkg.com/@agoric/wallet/-/wallet-0.18.3.tgz#5ca5b482036331f94c32f6a445b6e595cc3e8211"
-  integrity sha512-Pgk5uh2ZA3sg3hP+gpQ4jpg+qhIu5diKzzVnD5g4o2JeVYjDqsR/xpcOt7r7i8zNbNutCAgGu5/qDDYEMIV6zQ==
-  dependencies:
-    "@agoric/wallet-ui" "0.1.3-solo.0"
-    agoric "^0.21.1"
-    babel-eslint "^10.0.3"
-    eslint-plugin-eslint-comments "^3.1.2"
-    import-meta-resolve "^2.2.1"
-
-"@agoric/web-components@^0.15.0":
-  version "0.15.0"
-  resolved "https://registry.yarnpkg.com/@agoric/web-components/-/web-components-0.15.0.tgz#477317ccf9e0c967ff394add7efaca63546026ce"
-  integrity sha512-G1hl0NSgOuXE+9+SsyUpCHubhFJsrmFO7zo832EeJDUcO5d/V4M0YyrtIwFHKR2bH+IUl7JouasDO4fYEE8WYA==
+"@agoric/web-components@^0.17.0":
+  version "0.17.0"
+  resolved "https://registry.yarnpkg.com/@agoric/web-components/-/web-components-0.17.0.tgz#654e3fa07fdf0a2b6db40d8903b9be2972b1676b"
+  integrity sha512-eOgWAoRH7XpoGgVErInae/DrVFMLz4+Sj6NDNU1kLS6RxiW5/nC89FIRZHoVSO5YDisZnBuXh4seLlvzKtBbrg==
   dependencies:
     "@agoric/assert" "^0.6.0"
     "@agoric/cache" "^0.3.2"
     "@agoric/casting" "^0.4.3-u13.0"
-    "@agoric/ertp" "^0.16.2"
+    "@agoric/cosmic-proto" "0.3.0"
+    "@agoric/ertp" "^0.16.3-dev-e2e36cc.0"
     "@agoric/notifier" "^0.6.3-dev-8c14632.0"
     "@agoric/smart-wallet" "^0.5.3"
-    "@agoric/wallet" "^0.18.3"
     "@endo/captp" "^3.1.1"
     "@endo/eventual-send" "^0.17.5"
     "@endo/marshal" "^0.8.5"
-    "@endo/promise-kit" "^0.2.56"
-    "@lit-labs/react" "^1.0.1"
-    lit "2.0.2"
 
 "@agoric/xsnap-lockdown@0.14.1-dev-9f085d3.0+9f085d3":
   version "0.14.1-dev-9f085d3.0"
@@ -723,6 +809,17 @@
     "@agoric/vat-data" "^0.5.3-u13.0"
     "@endo/far" "0.2.18"
 
+"@agoric/zone@^0.3.0-u20.0":
+  version "0.3.0-u20.0"
+  resolved "https://registry.yarnpkg.com/@agoric/zone/-/zone-0.3.0-u20.0.tgz#909ec3a77cd34960a4a4b8f0ab5068ddddbf0358"
+  integrity sha512-u/N4LitfKuCokFlATjw8Qsm12PDylMwKXt/aHgqyCJKEK5OHk2k7ZrWW3H9Us8yZA4Ht/3BVxNk/GzP3bf8+3Q==
+  dependencies:
+    "@agoric/base-zone" "^0.1.1-u20.0"
+    "@agoric/vat-data" "^0.5.3-u20.0"
+    "@endo/errors" "^1.2.10"
+    "@endo/far" "^1.1.11"
+    "@endo/pass-style" "^1.5.0"
+
 "@alloc/quick-lru@^5.2.0":
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/@alloc/quick-lru/-/quick-lru-5.2.0.tgz#7bf68b20c0a350f936915fcae06f58e32007ce30"
@@ -736,13 +833,22 @@
     "@jridgewell/gen-mapping" "^0.3.0"
     "@jridgewell/trace-mapping" "^0.3.9"
 
-"@babel/code-frame@^7.0.0", "@babel/code-frame@^7.10.4", "@babel/code-frame@^7.23.5":
+"@babel/code-frame@^7.10.4", "@babel/code-frame@^7.23.5":
   version "7.23.5"
   resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.23.5.tgz#9009b69a8c602293476ad598ff53e4562e15c244"
   integrity sha512-CgH3s1a96LipHCmSUmYFPwY7MNx8C3avkq7i4Wl3cfa662ldtUe4VM1TPXX70pfmrlWTb6jLqTYrZyT2ZTJBgA==
   dependencies:
     "@babel/highlight" "^7.23.4"
     chalk "^2.4.2"
+
+"@babel/code-frame@^7.25.9", "@babel/code-frame@^7.27.1":
+  version "7.27.1"
+  resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.27.1.tgz#200f715e66d52a23b221a9435534a91cc13ad5be"
+  integrity sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==
+  dependencies:
+    "@babel/helper-validator-identifier" "^7.27.1"
+    js-tokens "^4.0.0"
+    picocolors "^1.1.1"
 
 "@babel/compat-data@^7.23.5":
   version "7.23.5"
@@ -800,6 +906,17 @@
     "@jridgewell/gen-mapping" "^0.3.2"
     "@jridgewell/trace-mapping" "^0.3.17"
     jsesc "^2.5.1"
+
+"@babel/generator@^7.25.9", "@babel/generator@^7.26.3":
+  version "7.27.3"
+  resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.27.3.tgz#ef1c0f7cfe3b5fc8cbb9f6cc69f93441a68edefc"
+  integrity sha512-xnlJYj5zepml8NXtjkG0WquFUv8RskFqyFcVgTBp5k+NaA/8uw/K+OSVf8AMGw5e9HKP2ETd5xpK5MLZQD6b4Q==
+  dependencies:
+    "@babel/parser" "^7.27.3"
+    "@babel/types" "^7.27.3"
+    "@jridgewell/gen-mapping" "^0.3.5"
+    "@jridgewell/trace-mapping" "^0.3.25"
+    jsesc "^3.0.2"
 
 "@babel/helper-annotate-as-pure@^7.22.5":
   version "7.22.5"
@@ -886,10 +1003,20 @@
   resolved "https://registry.yarnpkg.com/@babel/helper-string-parser/-/helper-string-parser-7.23.4.tgz#9478c707febcbbe1ddb38a3d91a2e054ae622d83"
   integrity sha512-803gmbQdqwdf4olxrX4AJyFBV/RTr3rSmOj0rKwesmzlfhYNDEs+/iOcznzpNWlJlIlTJC2QfPFcHB6DlzdVLQ==
 
+"@babel/helper-string-parser@^7.25.9", "@babel/helper-string-parser@^7.27.1":
+  version "7.27.1"
+  resolved "https://registry.yarnpkg.com/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz#54da796097ab19ce67ed9f88b47bb2ec49367687"
+  integrity sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==
+
 "@babel/helper-validator-identifier@^7.22.20":
   version "7.22.20"
   resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.22.20.tgz#c4ae002c61d2879e724581d96665583dbc1dc0e0"
   integrity sha512-Y4OZ+ytlatR8AI+8KZfKuL5urKp7qey08ha31L8b3BwewJAoJamTzyvxPR/5D+KkdJCGPq/+8TukHBlY10FX9A==
+
+"@babel/helper-validator-identifier@^7.25.9", "@babel/helper-validator-identifier@^7.27.1":
+  version "7.27.1"
+  resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.27.1.tgz#a7054dcc145a967dd4dc8fee845a57c1316c9df8"
+  integrity sha512-D2hP9eA+Sqx1kBZgzxZh0y1trbuU+JoDkiEwqhQ36nodYqJwyEIhPSdMNd7lOm/4io72luTPWH20Yda0xOuUow==
 
 "@babel/helper-validator-option@^7.23.5":
   version "7.23.5"
@@ -928,10 +1055,24 @@
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.24.0.tgz#26a3d1ff49031c53a97d03b604375f028746a9ac"
   integrity sha512-QuP/FxEAzMSjXygs8v4N9dvdXzEHN4W1oF3PxuWAtPo08UdM17u89RDMgjLn/mlc56iM0HlLmVkO/wgR+rDgHg==
 
-"@babel/parser@^7.17.3", "@babel/parser@^7.23.9", "@babel/parser@^7.7.0":
+"@babel/parser@^7.17.3", "@babel/parser@^7.23.9":
   version "7.23.9"
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.23.9.tgz#7b903b6149b0f8fa7ad564af646c4c38a77fc44b"
   integrity sha512-9tcKgqKbs3xGJ+NtKF2ndOBBLVwPjl1SHxPQkd36r3Dlirw3xWUeGaTbqr7uGZcTaxkVNwc+03SVP7aCdWrTlA==
+
+"@babel/parser@^7.25.9", "@babel/parser@^7.27.2", "@babel/parser@^7.27.3":
+  version "7.27.3"
+  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.27.3.tgz#1b7533f0d908ad2ac545c4d05cbe2fb6dc8cfaaf"
+  integrity sha512-xyYxRj6+tLNDTWi0KCBcZ9V7yg3/lwL9DWh9Uwh/RIVlIfFidggcgxKX3GCXwCiswwcGRawBKbEg2LG/Y8eJhw==
+  dependencies:
+    "@babel/types" "^7.27.3"
+
+"@babel/parser@~7.26.2":
+  version "7.26.10"
+  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.26.10.tgz#e9bdb82f14b97df6569b0b038edd436839c57749"
+  integrity sha512-6aQR2zGE/QFi8JpDLjUZEPYOs7+mhKXm86VaKFiLP35JQwQb6bwUE+XbvkH0EptsYhbNBSUGaUBLKqxH1xSgsA==
+  dependencies:
+    "@babel/types" "^7.26.10"
 
 "@babel/plugin-syntax-jsx@^7.22.5", "@babel/plugin-syntax-jsx@^7.23.3":
   version "7.23.3"
@@ -1012,7 +1153,16 @@
     "@babel/parser" "^7.24.0"
     "@babel/types" "^7.24.0"
 
-"@babel/traverse@^7.17.3", "@babel/traverse@^7.23.9", "@babel/traverse@^7.4.5", "@babel/traverse@^7.7.0":
+"@babel/template@^7.25.9":
+  version "7.27.2"
+  resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.27.2.tgz#fa78ceed3c4e7b63ebf6cb39e5852fca45f6809d"
+  integrity sha512-LPDZ85aEJyYSd18/DkjNh4/y1ntkE5KwUHWTiqgRxruuZL2F1yuHligVHLvcHY2vMHXttKFpJn6LwfI7cw7ODw==
+  dependencies:
+    "@babel/code-frame" "^7.27.1"
+    "@babel/parser" "^7.27.2"
+    "@babel/types" "^7.27.1"
+
+"@babel/traverse@^7.17.3", "@babel/traverse@^7.23.9", "@babel/traverse@^7.4.5":
   version "7.23.9"
   resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.23.9.tgz#2f9d6aead6b564669394c5ce0f9302bb65b9d950"
   integrity sha512-I/4UJ9vs90OkBtY6iiiTORVMyIhJ4kAVmsKo9KFc8UOxMeUfi2hvtIBsET5u9GizXE6/GFSuKCTNfgCswuEjRg==
@@ -1044,7 +1194,20 @@
     debug "^4.3.1"
     globals "^11.1.0"
 
-"@babel/types@^7.17.0", "@babel/types@^7.22.15", "@babel/types@^7.22.5", "@babel/types@^7.23.0", "@babel/types@^7.23.4", "@babel/types@^7.23.6", "@babel/types@^7.23.9", "@babel/types@^7.7.0":
+"@babel/traverse@~7.25.9":
+  version "7.25.9"
+  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.25.9.tgz#a50f8fe49e7f69f53de5bea7e413cd35c5e13c84"
+  integrity sha512-ZCuvfwOwlz/bawvAuvcj8rrithP2/N55Tzz342AkTvq4qaWbGfmCk/tKhNaV2cthijKrPAA8SRJV5WWe7IBMJw==
+  dependencies:
+    "@babel/code-frame" "^7.25.9"
+    "@babel/generator" "^7.25.9"
+    "@babel/parser" "^7.25.9"
+    "@babel/template" "^7.25.9"
+    "@babel/types" "^7.25.9"
+    debug "^4.3.1"
+    globals "^11.1.0"
+
+"@babel/types@^7.17.0", "@babel/types@^7.22.15", "@babel/types@^7.22.5", "@babel/types@^7.23.0", "@babel/types@^7.23.4", "@babel/types@^7.23.6", "@babel/types@^7.23.9":
   version "7.23.9"
   resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.23.9.tgz#1dd7b59a9a2b5c87f8b41e52770b5ecbf492e002"
   integrity sha512-dQjSq/7HaSjRM43FFGnv5keM2HsxpmyV1PfaSVm0nzzjwwTmjOe6J4bC8e3+pTEIgHaHj+1ZlLThRJ2auc/w1Q==
@@ -1061,6 +1224,22 @@
     "@babel/helper-string-parser" "^7.23.4"
     "@babel/helper-validator-identifier" "^7.22.20"
     to-fast-properties "^2.0.0"
+
+"@babel/types@^7.25.9", "@babel/types@^7.26.10", "@babel/types@^7.27.1", "@babel/types@^7.27.3":
+  version "7.27.3"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.27.3.tgz#c0257bedf33aad6aad1f406d35c44758321eb3ec"
+  integrity sha512-Y1GkI4ktrtvmawoSq+4FCVHNryea6uR+qUQy0AGxLSsjCX0nVmkYQMBLHDkXZuo5hGx7eYdnIaslsdBFm7zbUw==
+  dependencies:
+    "@babel/helper-string-parser" "^7.27.1"
+    "@babel/helper-validator-identifier" "^7.27.1"
+
+"@babel/types@~7.26.0":
+  version "7.26.10"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.26.10.tgz#396382f6335bd4feb65741eacfc808218f859259"
+  integrity sha512-emqcG3vHrpxUKTrxcblR36dcrcoRDvKmnL/dCL6ZsHaShW80qxCAcNhzQZrpeM765VzEos+xOi4s+r4IXzTwdQ==
+  dependencies:
+    "@babel/helper-string-parser" "^7.25.9"
+    "@babel/helper-validator-identifier" "^7.25.9"
 
 "@coinbase/wallet-sdk@^3.6.6":
   version "3.7.2"
@@ -1666,6 +1845,11 @@
   resolved "https://registry.yarnpkg.com/@endo/base64/-/base64-0.2.35.tgz#7d18203d5807748388c935df7eb79c7672a0b64e"
   integrity sha512-rsAicKvgNq/ar+9b3ElXRXglMiJcg1IErz3lx1HFYZUzfWp8r/Dibi3TEjYpSBmtOeYN9CeWH8CBluN0uFqdag==
 
+"@endo/base64@^1.0.9":
+  version "1.0.9"
+  resolved "https://registry.yarnpkg.com/@endo/base64/-/base64-1.0.9.tgz#53a05e8d461a63443097165397a7aef33a11b251"
+  integrity sha512-iUZJSE3EeFxHgk5pRaj83Tv6B0BJHJOpV6UqGv0K3UBn4azQysWRR5IzlXzxcVIpPiSVlOhG/6uCqTxP5cE1ug==
+
 "@endo/bundle-source@2.5.2-upstream-rollup":
   version "2.5.2-upstream-rollup"
   resolved "https://registry.yarnpkg.com/@endo/bundle-source/-/bundle-source-2.5.2-upstream-rollup.tgz#89fdc6b1b6625ca8c484c12e7762f04cd711ca9f"
@@ -1746,6 +1930,20 @@
   resolved "https://registry.yarnpkg.com/@endo/cjs-module-analyzer/-/cjs-module-analyzer-0.2.35.tgz#0de39d2306bba5671e121efa091bf6cb9990f11e"
   integrity sha512-Ldr1auybH9AzrR/WV6bzP4aLRpv8CCl98mv0IAui4uQmmFOPOGchshyBfpiDF5XMKM6wh7z0VgmvmydQ5/7AHQ==
 
+"@endo/cjs-module-analyzer@^1.0.9":
+  version "1.0.9"
+  resolved "https://registry.yarnpkg.com/@endo/cjs-module-analyzer/-/cjs-module-analyzer-1.0.9.tgz#09f042e1e828dce7e2a3729e1b3a7667eb3e30f4"
+  integrity sha512-uc6SJx0BzTz/JQ2A2SPt2eMVcIZRLyJ9LF94esuQaNoC8ZJOiCDOY7OmiwdIL+xO9qL9uA4sne5/kRTc9bDGEg==
+
+"@endo/common@^1.2.10":
+  version "1.2.10"
+  resolved "https://registry.yarnpkg.com/@endo/common/-/common-1.2.10.tgz#d54b1f9de619232ac339e6e43afbd8aa61cf65a6"
+  integrity sha512-28scwUdjlrvFjORcPsMoXaz5a2p6eNmgnYTA9AhjNwn7OILgqhd4TVqjKLFi7lDI6FADawa6kttqkBzc2fPang==
+  dependencies:
+    "@endo/errors" "^1.2.10"
+    "@endo/eventual-send" "^1.3.1"
+    "@endo/promise-kit" "^1.1.10"
+
 "@endo/compartment-mapper@0.8.4":
   version "0.8.4"
   resolved "https://registry.yarnpkg.com/@endo/compartment-mapper/-/compartment-mapper-0.8.4.tgz#afae6a4dfc64dff7082e90d7f215a072fb0a9b85"
@@ -1776,6 +1974,17 @@
     "@endo/zip" "^0.2.35"
     ses "^0.18.8"
 
+"@endo/compartment-mapper@^1.6.0":
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/@endo/compartment-mapper/-/compartment-mapper-1.6.0.tgz#87738341bb9635340964952cada9ee70bb596498"
+  integrity sha512-EIg2tAfye82VfJUlmwGTQE3vQFfWDLBMQ1+U5EorSx2AxawHBD8Y7eG/vomrRh7GSZUoOCAtMsWiYZoeb1vI/Q==
+  dependencies:
+    "@endo/cjs-module-analyzer" "^1.0.9"
+    "@endo/module-source" "^1.3.0"
+    "@endo/trampoline" "^1.0.3"
+    "@endo/zip" "^1.0.9"
+    ses "^1.12.0"
+
 "@endo/env-options@^0.1.4":
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/@endo/env-options/-/env-options-0.1.4.tgz#e516bc3864f00b154944e444fb8996a9a0c23a45"
@@ -1785,6 +1994,18 @@
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/@endo/env-options/-/env-options-1.1.1.tgz#eee630f8eff01580ec49e0dedcb1b6cef05d89a4"
   integrity sha512-uCwlJ8Vkndx/VBBo36BdYHdxSoQPy7ZZpwyJNfv86Rh4B1IZfqzCRPf0u0mPgJdzOr7lShQey60SuYwoMSZ9Xg==
+
+"@endo/env-options@^1.1.8":
+  version "1.1.8"
+  resolved "https://registry.yarnpkg.com/@endo/env-options/-/env-options-1.1.8.tgz#dbfcfbf7574f2a793155281d035c8d6f809f5828"
+  integrity sha512-Xtxw9n33I4guo8q0sDyZiRuxlfaopM454AKiELgU7l3tqsylCut6IBZ0fPy4ltSHsBib7M3yF7OEMoIuLwzWVg==
+
+"@endo/errors@^1.2.10":
+  version "1.2.10"
+  resolved "https://registry.yarnpkg.com/@endo/errors/-/errors-1.2.10.tgz#8fcad085926676fd0062303debd8390a0d33f507"
+  integrity sha512-GIxTAlZeS9lfvj09/k8trmC1HBwEihMhLAXQT61PnNy/AGqXTncPAkvXkGEF/sfuVTRh7SeQQ2kK5hGyqC1hQw==
+  dependencies:
+    ses "^1.12.0"
 
 "@endo/eventual-send@0.17.2":
   version "0.17.2"
@@ -1805,6 +2026,13 @@
   dependencies:
     "@endo/env-options" "^1.1.1"
 
+"@endo/eventual-send@^1.3.1":
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/@endo/eventual-send/-/eventual-send-1.3.1.tgz#1204d79b3ad250f92b55a8c3befd9da861823e21"
+  integrity sha512-Xz+baNUArvHea2WQ3VYNzhk/UKTufQy3l7sCyi/wAouwTOwpze4HKEZWphVk9BSSh3vsWXDCLtKVvzNl4EOmRg==
+  dependencies:
+    "@endo/env-options" "^1.1.8"
+
 "@endo/exo@0.2.2":
   version "0.2.2"
   resolved "https://registry.yarnpkg.com/@endo/exo/-/exo-0.2.2.tgz#eeebe3eeb40dcf9b409fddf8d5ff73821b470515"
@@ -1823,6 +2051,19 @@
     "@endo/pass-style" "^0.1.7"
     "@endo/patterns" "^0.2.6"
 
+"@endo/exo@^1.5.9":
+  version "1.5.9"
+  resolved "https://registry.yarnpkg.com/@endo/exo/-/exo-1.5.9.tgz#60d41e19276e18925450d506a9688f553c7e2d23"
+  integrity sha512-OOqLDtj1UZb6XXIMX1uLf7h222kZXokSJX8Eo6cFGNAZ5tla4QdSTZdOMcDr3P3Argwt/IGOYuTmaa0AkJdCsA==
+  dependencies:
+    "@endo/common" "^1.2.10"
+    "@endo/env-options" "^1.1.8"
+    "@endo/errors" "^1.2.10"
+    "@endo/eventual-send" "^1.3.1"
+    "@endo/far" "^1.1.11"
+    "@endo/pass-style" "^1.5.0"
+    "@endo/patterns" "^1.5.0"
+
 "@endo/far@0.2.18":
   version "0.2.18"
   resolved "https://registry.yarnpkg.com/@endo/far/-/far-0.2.18.tgz#8d8ca8ac1f7c4b57871e55c2c2f06c8e4fcf3839"
@@ -1838,6 +2079,15 @@
   dependencies:
     "@endo/eventual-send" "^0.17.6"
     "@endo/pass-style" "^0.1.7"
+
+"@endo/far@^1.0.0", "@endo/far@^1.1.11":
+  version "1.1.11"
+  resolved "https://registry.yarnpkg.com/@endo/far/-/far-1.1.11.tgz#39a2a7a88525dc34e26f93a30f4171eb1c907cce"
+  integrity sha512-XeTcUP2vCtbNPizim9ZXYCHx4fYb6S4DGcbkFFy1LjhVDOsgWqUGpsv1ZthbOaLkc+MIlihLZ+KIpS7vT17POA==
+  dependencies:
+    "@endo/errors" "^1.2.10"
+    "@endo/eventual-send" "^1.3.1"
+    "@endo/pass-style" "^1.5.0"
 
 "@endo/import-bundle@0.3.4":
   version "0.3.4"
@@ -1875,6 +2125,16 @@
     "@endo/lockdown" "^0.1.32"
     "@endo/promise-kit" "^0.2.60"
 
+"@endo/init@^1.1.9":
+  version "1.1.9"
+  resolved "https://registry.yarnpkg.com/@endo/init/-/init-1.1.9.tgz#e2506abdb17bcd38ab6685608b75cc7789899e61"
+  integrity sha512-YDl4zHUv54ghuau2tSC08xwSDu/QhmTmOdxWgJNlj29bwe5n3s3G8j5jbzx6FNqdZq0W2ow9uzKdpEczpFy+Uw==
+  dependencies:
+    "@endo/base64" "^1.0.9"
+    "@endo/eventual-send" "^1.3.1"
+    "@endo/lockdown" "^1.0.15"
+    "@endo/promise-kit" "^1.1.10"
+
 "@endo/lockdown@0.1.28":
   version "0.1.28"
   resolved "https://registry.yarnpkg.com/@endo/lockdown/-/lockdown-0.1.28.tgz#43f23dcbb12b6ebd3ad2a3dc8c6bb3609dd9e95f"
@@ -1888,6 +2148,13 @@
   integrity sha512-AN696XS3robsopxVg7gc/6c9TXPGosGmKfcM0g9SNnD1rqgo1EakS4wf7f3AbICU9iJdo0e4V5JjzWPnjqoR0g==
   dependencies:
     ses "^0.18.8"
+
+"@endo/lockdown@^1.0.15":
+  version "1.0.15"
+  resolved "https://registry.yarnpkg.com/@endo/lockdown/-/lockdown-1.0.15.tgz#35030381a34ac7d68031517142b7bca2b261f3d9"
+  integrity sha512-UFnsGkT7n4J4jtkFbgo8f4ENGctcbZqtIvGMWGLEO2p7ZsvCnOZhStuHZKt9Vx1u/5IAv/X8/+RCUkyGTsM03w==
+  dependencies:
+    ses "^1.12.0"
 
 "@endo/marshal@0.8.5":
   version "0.8.5"
@@ -1909,6 +2176,29 @@
     "@endo/pass-style" "^0.1.7"
     "@endo/promise-kit" "^0.2.60"
 
+"@endo/marshal@^1.6.4":
+  version "1.6.4"
+  resolved "https://registry.yarnpkg.com/@endo/marshal/-/marshal-1.6.4.tgz#47f76871edf1745f171d0ca7c0c4408b7b79aabf"
+  integrity sha512-HpTNDDPLjLAHmE5WjWxObmkqpJAyDX4yDARfOzqjEGvJTtdj8hePbV3wfrTMqg2DdaUOuKN2xFAjSCsN6S+GXA==
+  dependencies:
+    "@endo/common" "^1.2.10"
+    "@endo/errors" "^1.2.10"
+    "@endo/eventual-send" "^1.3.1"
+    "@endo/nat" "^5.1.0"
+    "@endo/pass-style" "^1.5.0"
+    "@endo/promise-kit" "^1.1.10"
+
+"@endo/module-source@^1.3.0":
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/@endo/module-source/-/module-source-1.3.0.tgz#633aa6d23091c10190fefb63ebd934dd17260914"
+  integrity sha512-waFivuJYvPRKP+W01XAw+Hz1X81Bb05IDhrcFJXFaVil7B6hxByQ6aUeYeGFugCfke51DzvzSE1RbDnWy2u/7Q==
+  dependencies:
+    "@babel/generator" "^7.26.3"
+    "@babel/parser" "~7.26.2"
+    "@babel/traverse" "~7.25.9"
+    "@babel/types" "~7.26.0"
+    ses "^1.12.0"
+
 "@endo/nat@4.1.27":
   version "4.1.27"
   resolved "https://registry.yarnpkg.com/@endo/nat/-/nat-4.1.27.tgz#8f1a398b39f994b0769070a3fb36d3397bf86794"
@@ -1918,6 +2208,11 @@
   version "4.1.31"
   resolved "https://registry.yarnpkg.com/@endo/nat/-/nat-4.1.31.tgz#ca738f472481a572f47749b41529b3261ebb4c1e"
   integrity sha512-tz0PnEmzX9BAtKEawYndsx+XC6f+2CKErtrpbpOuX3uct5VNLdw6q6cArSYtnHbxRHR0YaHUdeG0W6okmup4bg==
+
+"@endo/nat@^5.1.0":
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/@endo/nat/-/nat-5.1.0.tgz#c0c1a780dca7bffb942c6e8e217687bbef8d87ce"
+  integrity sha512-k0Kdfx8pOGJVHHeQtrauHGVZXuhq9lmcapi4LjlxNRqnNcInnMC13amkilENLUKTQqW/r6Wlvq3V/vvz4O1EfA==
 
 "@endo/netstring@^0.3.27":
   version "0.3.30"
@@ -1944,6 +2239,16 @@
     "@endo/promise-kit" "^0.2.60"
     "@fast-check/ava" "^1.1.5"
 
+"@endo/pass-style@^1.5.0":
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/@endo/pass-style/-/pass-style-1.5.0.tgz#19dd058055afde71d26a4f19133325f641c7d6a7"
+  integrity sha512-eH+JWkk0bU9y7kcTNWlwfnO7Q+dmkx6r9RqdsixkN2PioaLsRh4qQWhA69sBJ23CUFA/+Y+gao2d9FYTsNtP6A==
+  dependencies:
+    "@endo/env-options" "^1.1.8"
+    "@endo/errors" "^1.2.10"
+    "@endo/eventual-send" "^1.3.1"
+    "@endo/promise-kit" "^1.1.10"
+
 "@endo/patterns@0.2.2":
   version "0.2.2"
   resolved "https://registry.yarnpkg.com/@endo/patterns/-/patterns-0.2.2.tgz#d4c4d63bf450477ed9a9cf194b4a8daa56fcb4f4"
@@ -1962,6 +2267,18 @@
     "@endo/marshal" "^0.8.9"
     "@endo/promise-kit" "^0.2.60"
 
+"@endo/patterns@^1.5.0":
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/@endo/patterns/-/patterns-1.5.0.tgz#5c32d644b2628125ef245c0ef807f9d757271a80"
+  integrity sha512-DqDWgX483/yrSOdfpbajtZjxDnc6Bl+W0AQUbX1tKVmdyHcpyVfYdeyzPgd3+k2mKl8PJ5Ry0PHmyrLqx6ikCg==
+  dependencies:
+    "@endo/common" "^1.2.10"
+    "@endo/errors" "^1.2.10"
+    "@endo/eventual-send" "^1.3.1"
+    "@endo/marshal" "^1.6.4"
+    "@endo/pass-style" "^1.5.0"
+    "@endo/promise-kit" "^1.1.10"
+
 "@endo/promise-kit@0.2.56":
   version "0.2.56"
   resolved "https://registry.yarnpkg.com/@endo/promise-kit/-/promise-kit-0.2.56.tgz#24ed3cf87af1eec65f4635643b7e67617b909e71"
@@ -1975,6 +2292,13 @@
   integrity sha512-6Zp9BqBbc3ywaG+iLRrQRmO/VLKrMnvsbgOKKPMpjEC3sUlksYA09uaH3GrKZgoGChF8m9bXK8eFW39z7wJNUw==
   dependencies:
     ses "^0.18.8"
+
+"@endo/promise-kit@^1.1.10":
+  version "1.1.10"
+  resolved "https://registry.yarnpkg.com/@endo/promise-kit/-/promise-kit-1.1.10.tgz#1fa28f5f42ca42b417f5ad9476f58391696de59a"
+  integrity sha512-h1vrL1XLeboaFTUBji8PmPcepPNMVS5aleXOufz5bh0TSBGslaNoMPnpoC3AdBYjKTEF+BFX3qXFUYEoipTfjg==
+  dependencies:
+    ses "^1.12.0"
 
 "@endo/ses-ava@0.2.40":
   version "0.2.40"
@@ -2032,6 +2356,20 @@
     "@endo/promise-kit" "^0.2.60"
     ses "^0.18.8"
 
+"@endo/stream@^1.2.10":
+  version "1.2.10"
+  resolved "https://registry.yarnpkg.com/@endo/stream/-/stream-1.2.10.tgz#d8e6c4a6bfe8f648fb213702c9c5987cde62e1d9"
+  integrity sha512-jd16MKoiD0nN1Z5CGrmmk4lknmCW553eFbQQZVf/xuqWoIGi/Xe3sphTcnbvcK7duuvVaw2u6GDfY6mQPT08Rg==
+  dependencies:
+    "@endo/eventual-send" "^1.3.1"
+    "@endo/promise-kit" "^1.1.10"
+    ses "^1.12.0"
+
+"@endo/trampoline@^1.0.3":
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/@endo/trampoline/-/trampoline-1.0.3.tgz#24bcd3dee5645a747a37f284716709ffd02ec3cd"
+  integrity sha512-TYtvWSc97yV/LZDRc5mD4Wt9toKm2UyVjv66FAFiQRsoeKkEaXbus9Ka9byV1MwZv0P1xhCJ5yPV5Q6F9w0Wpw==
+
 "@endo/where@^0.3.5":
   version "0.3.5"
   resolved "https://registry.yarnpkg.com/@endo/where/-/where-0.3.5.tgz#df7661ec38ab6a327ef050aa88b50555876c39ef"
@@ -2046,6 +2384,11 @@
   version "0.2.35"
   resolved "https://registry.yarnpkg.com/@endo/zip/-/zip-0.2.35.tgz#37a7f9266ca9c9167de5e42b55b0d9c979598d87"
   integrity sha512-UM+mMZjBtJf33lXj38xXIEIe1B5wrgg/nT9CHrC8s+Pj/h63eMpQmcJzjL2vMKrvq3Tsj+TDzmQhtYcbrFACqQ==
+
+"@endo/zip@^1.0.9":
+  version "1.0.9"
+  resolved "https://registry.yarnpkg.com/@endo/zip/-/zip-1.0.9.tgz#f16b68d3e03f838de762779e5c9aa1731a27c1fc"
+  integrity sha512-Iuvm6oZBVQVKpLG6KtjdyTOF2od2lOdjEr2a2UC3ppCxAJRSDC9EQMsE0kkHQra5caRj1JERnoQlqYgn0ZC7ug==
 
 "@esbuild/aix-ppc64@0.19.12":
   version "0.19.12"
@@ -2899,17 +3242,12 @@
   resolved "https://registry.yarnpkg.com/@leichtgewicht/ip-codec/-/ip-codec-2.0.4.tgz#b2ac626d6cb9c8718ab459166d4bb405b8ffa78b"
   integrity sha512-Hcv+nVC0kZnQ3tD9GVu5xSMR4VVYOteQIr/hwFPVEvPdlXqgGEuRjiheChHgdM+JyqdgNcmzZOX/tnl0JOiI7A==
 
-"@lit-labs/react@^1.0.1":
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/@lit-labs/react/-/react-1.2.1.tgz#5b421502cdf68a3639dec431318eeed2285f1c0e"
-  integrity sha512-DiZdJYFU0tBbdQkfwwRSwYyI/mcWkg3sWesKRsHUd4G+NekTmmeq9fzsurvcKTNVa0comNljwtg4Hvi1ds3V+A==
-
 "@lit-labs/ssr-dom-shim@^1.0.0", "@lit-labs/ssr-dom-shim@^1.1.0":
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/@lit-labs/ssr-dom-shim/-/ssr-dom-shim-1.2.0.tgz#353ce4a76c83fadec272ea5674ede767650762fd"
   integrity sha512-yWJKmpGE6lUURKAaIltoPIE/wrbY3TEkqQt+X0m+7fQNnAv0keydnYvbiJFP1PnMhizmIWRWOG5KLhYyc/xl+g==
 
-"@lit/reactive-element@^1.0.0", "@lit/reactive-element@^1.3.0", "@lit/reactive-element@^1.6.0":
+"@lit/reactive-element@^1.3.0", "@lit/reactive-element@^1.6.0":
   version "1.6.3"
   resolved "https://registry.yarnpkg.com/@lit/reactive-element/-/reactive-element-1.6.3.tgz#25b4eece2592132845d303e091bad9b04cdcfe03"
   integrity sha512-QuTgnG52Poic7uM1AN5yJ09QMe0O28e10XzSvWDz02TJiiKee4stsiownEIadWm8nYzyDAyT+gKzUoZmiWQtsQ==
@@ -5287,18 +5625,6 @@ axobject-query@^3.2.1:
   dependencies:
     dequal "^2.0.3"
 
-babel-eslint@^10.0.3:
-  version "10.1.0"
-  resolved "https://registry.yarnpkg.com/babel-eslint/-/babel-eslint-10.1.0.tgz#6968e568a910b78fb3779cdd8b6ac2f479943232"
-  integrity sha512-ifWaTHQ0ce+448CYop8AdrQiBsGrnC+bMgfyKFdi6EsPLTAWG+QfyDeM6OH+FmWnKvEq5NnBMLvlBUPKQZoDSg==
-  dependencies:
-    "@babel/code-frame" "^7.0.0"
-    "@babel/parser" "^7.7.0"
-    "@babel/traverse" "^7.7.0"
-    "@babel/types" "^7.7.0"
-    eslint-visitor-keys "^1.0.0"
-    resolve "^1.12.0"
-
 babel-plugin-istanbul@^6.1.1:
   version "6.1.1"
   resolved "https://registry.yarnpkg.com/babel-plugin-istanbul/-/babel-plugin-istanbul-6.1.1.tgz#fa88ec59232fd9b4e36dbbc540a8ec9a9b47da73"
@@ -7179,14 +7505,6 @@ eslint-module-utils@^2.8.0:
   dependencies:
     debug "^3.2.7"
 
-eslint-plugin-eslint-comments@^3.1.2:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-eslint-comments/-/eslint-plugin-eslint-comments-3.2.0.tgz#9e1cd7b4413526abb313933071d7aba05ca12ffa"
-  integrity sha512-0jkOl0hfojIHHmEHgmNdqv4fmh7300NdpA9FFpF7zaoLvB/QeXOGNLIo86oAveJFrfB1p05kC8hpEMHM8DwWVQ==
-  dependencies:
-    escape-string-regexp "^1.0.5"
-    ignore "^5.0.5"
-
 eslint-plugin-import@^2.26.0:
   version "2.29.1"
   resolved "https://registry.yarnpkg.com/eslint-plugin-import/-/eslint-plugin-import-2.29.1.tgz#d45b37b5ef5901d639c15270d74d46d161150643"
@@ -7274,11 +7592,6 @@ eslint-scope@^7.2.2:
   dependencies:
     esrecurse "^4.3.0"
     estraverse "^5.2.0"
-
-eslint-visitor-keys@^1.0.0:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz#30ebd1ef7c2fdff01c3a4f151044af25fab0523e"
-  integrity sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==
 
 eslint-visitor-keys@^3.3.0, eslint-visitor-keys@^3.4.1, eslint-visitor-keys@^3.4.3:
   version "3.4.3"
@@ -8737,7 +9050,7 @@ ieee754@^1.1.13, ieee754@^1.1.8, ieee754@^1.2.1:
   resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.2.1.tgz#8eb7a10a63fff25d15a57b001586d177d1b0d352"
   integrity sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==
 
-ignore@^5.0.5, ignore@^5.2.0, ignore@^5.2.4:
+ignore@^5.2.0, ignore@^5.2.4:
   version "5.3.1"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.3.1.tgz#5073e554cd42c5b33b394375f538b8593e34d4ef"
   integrity sha512-5Fytz/IraMjqpwfd34ke28PTVMjZjJG2MPn5t7OE4eUCUNf8BAa7b5WUS9/Qvr6mwOQS7Mk6vdsMno5he+T8Xw==
@@ -9386,6 +9699,13 @@ jessie.js@^0.3.2:
   dependencies:
     "@endo/far" "^0.2.3"
 
+jessie.js@^0.3.4:
+  version "0.3.4"
+  resolved "https://registry.yarnpkg.com/jessie.js/-/jessie.js-0.3.4.tgz#7e35dadc91cf4740d2ddc8a58b6cd0a99eb64a08"
+  integrity sha512-JYJm6nXuFIO/X6OWLBatorgqmFVYbenqnFP0UDalO2OQ6sn58VeJ3cKtMQ0l0TM0JnCx4wKhyO4BQQ/ilxjd6g==
+  dependencies:
+    "@endo/far" "^1.0.0"
+
 jest-docblock@^29.7.0:
   version "29.7.0"
   resolved "https://registry.yarnpkg.com/jest-docblock/-/jest-docblock-29.7.0.tgz#8fddb6adc3cdc955c93e2a87f61cfd350d5d119a"
@@ -9460,6 +9780,11 @@ jsesc@^2.5.1:
   version "2.5.2"
   resolved "https://registry.yarnpkg.com/jsesc/-/jsesc-2.5.2.tgz#80564d2e483dacf6e8ef209650a67df3f0c283a4"
   integrity sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==
+
+jsesc@^3.0.2:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/jsesc/-/jsesc-3.1.0.tgz#74d335a234f67ed19907fdadfac7ccf9d409825d"
+  integrity sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==
 
 json-buffer@3.0.0:
   version "3.0.0"
@@ -9740,7 +10065,7 @@ listr2@^3.8.3:
     through "^2.3.8"
     wrap-ansi "^7.0.0"
 
-lit-element@^3.0.0, lit-element@^3.3.0:
+lit-element@^3.3.0:
   version "3.3.3"
   resolved "https://registry.yarnpkg.com/lit-element/-/lit-element-3.3.3.tgz#10bc19702b96ef5416cf7a70177255bfb17b3209"
   integrity sha512-XbeRxmTHubXENkV4h8RIPyr8lXc+Ff28rkcQzw3G6up2xg5E8Zu1IgOWIwBLEQsu3cOVFqdYwiVi0hv0SlpqUA==
@@ -9749,21 +10074,12 @@ lit-element@^3.0.0, lit-element@^3.3.0:
     "@lit/reactive-element" "^1.3.0"
     lit-html "^2.8.0"
 
-lit-html@^2.0.0, lit-html@^2.8.0:
+lit-html@^2.8.0:
   version "2.8.0"
   resolved "https://registry.yarnpkg.com/lit-html/-/lit-html-2.8.0.tgz#96456a4bb4ee717b9a7d2f94562a16509d39bffa"
   integrity sha512-o9t+MQM3P4y7M7yNzqAyjp7z+mQGa4NS4CxiyLqFPyFWyc4O+nodLrkrxSaCTrla6M5YOLaT3RpbbqjszB5g3Q==
   dependencies:
     "@types/trusted-types" "^2.0.2"
-
-lit@2.0.2:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/lit/-/lit-2.0.2.tgz#5e6f422924e0732258629fb379556b6d23f7179c"
-  integrity sha512-hKA/1YaSB+P+DvKWuR2q1Xzy/iayhNrJ3aveD0OQ9CKn6wUjsdnF/7LavDOJsKP/K5jzW/kXsuduPgRvTFrFJw==
-  dependencies:
-    "@lit/reactive-element" "^1.0.0"
-    lit-element "^3.0.0"
-    lit-html "^2.0.0"
 
 lit@2.8.0:
   version "2.8.0"
@@ -10924,6 +11240,11 @@ picocolors@^1.0.0:
   resolved "https://registry.yarnpkg.com/picocolors/-/picocolors-1.0.0.tgz#cb5bdc74ff3f51892236eaf79d68bc44564ab81c"
   integrity sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==
 
+picocolors@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/picocolors/-/picocolors-1.1.1.tgz#3d321af3eab939b083c8f929a1d12cda81c26b6b"
+  integrity sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==
+
 picomatch@^2.0.4, picomatch@^2.2.1, picomatch@^2.2.2, picomatch@^2.3.1:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.3.1.tgz#3ba3833733646d9d3e4995946c1365a67fb07a42"
@@ -11693,7 +12014,7 @@ resolve-from@^5.0.0:
   resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-5.0.0.tgz#c35225843df8f776df21c57557bc087e9dfdfc69"
   integrity sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==
 
-resolve@^1.1.7, resolve@^1.12.0, resolve@^1.17.0, resolve@^1.19.0, resolve@^1.22.2, resolve@^1.22.4:
+resolve@^1.1.7, resolve@^1.17.0, resolve@^1.19.0, resolve@^1.22.2, resolve@^1.22.4:
   version "1.22.8"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.22.8.tgz#b6c87a9f2aa06dfab52e3d70ac8cde321fa5a48d"
   integrity sha512-oKWePCxqpd6FlLvGV1VU0x7bkPmmCNolxzjMf4NczoDnQcIWrAF+cPtZn5i6n+RfD2d9i0tzpKnG6Yk168yIyw==
@@ -11979,6 +12300,13 @@ ses@^0.18.4, ses@^0.18.5, ses@^0.18.8:
   integrity sha512-kOH1AhJc6gWDXKURKeU1w7iFUdImAegAljVvBg5EUBgNqjH4bxcEsGVUadVEPtA2PVRMyQp1fiSMDwEZkQNj1g==
   dependencies:
     "@endo/env-options" "^0.1.4"
+
+ses@^1.12.0:
+  version "1.12.0"
+  resolved "https://registry.yarnpkg.com/ses/-/ses-1.12.0.tgz#f3cf22f67126cbd373aea0c501753952653699b1"
+  integrity sha512-jvmwXE2lFxIIY1j76hFjewIIhYMR9Slo3ynWZGtGl5M7VUCw3EA0wetS+JCIbl2UcSQjAT0yGAHkyxPJreuC9w==
+  dependencies:
+    "@endo/env-options" "^1.1.8"
 
 ses@^1.3.0:
   version "1.3.0"


### PR DESCRIPTION
Changes the provision smart wallet notice / onboard ist modal to support bld as well when it's set as the swingset fee.

Upgrades @agoric/web-components which now uses BLD only as the fee token for the wallet connection.

Removes the "tsc" step in build because vite already compiles it and I got an error in node_modules when upgrading @agoric/web-components https://gist.github.com/samsiegart/7794b51ef6875a14fc5521a53bf9fdb0